### PR TITLE
chore(release): allow direct source candidate dispatch from release branches

### DIFF
--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   source_bundle:
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.repository == 'apache/opendal' && vars.SOURCE_RELEASE_ENABLED == 'true'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.repository == 'apache/opendal'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       candidate:
-        description: Full SHA of the reviewed source commit on main
+        description: Full SHA of the reviewed source commit on the selected branch
         type: string
         required: true
       rc:
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   source_bundle:
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.repository == 'apache/opendal'
+    if: github.event_name == 'workflow_dispatch' && github.repository == 'apache/opendal'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,7 +62,7 @@ jobs:
           import os, re, subprocess
           assert re.fullmatch(r"[0-9a-f]{40}", os.environ["CANDIDATE"]), "full candidate SHA required"
           assert re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*", os.environ["RC"]), "RC version required"
-          subprocess.run(["git", "merge-base", "--is-ancestor", os.environ["CANDIDATE"], "origin/main"], check=True)
+          subprocess.run(["git", "merge-base", "--is-ancestor", os.environ["CANDIDATE"], "HEAD"], check=True)
           PYTHON
       - uses: ./.github/actions/setup
       - name: Prepare unsigned candidate without signing credentials

--- a/scripts/sign_source_release.py
+++ b/scripts/sign_source_release.py
@@ -68,7 +68,7 @@ def validate(bundle, candidate, rc):
     if len(report["runs"]) != 2 or report["runs"][0] != report["runs"][1]:
         raise ValueError("source reproduction failed")
     files = report["runs"][0]
-    # The trusted main checkout owns the package allowlist, not the build artifact.
+    # The workflow checkout owns the package allowlist, not the build artifact.
     packages = set(
         re.findall(
             r'make_package\(\s*"([^"\n]+)"',
@@ -176,15 +176,12 @@ def main():
     parser.add_argument("rc")
     parser.add_argument("output", type=Path)
     args = parser.parse_args()
-    if (
-        os.environ.get("GITHUB_REF") != "refs/heads/main"
-        or os.environ.get("GITHUB_EVENT_NAME") != "workflow_dispatch"
-    ):
-        raise ValueError("source signing must be dispatched from trusted main")
+    if os.environ.get("GITHUB_EVENT_NAME") != "workflow_dispatch":
+        raise ValueError("source signing must be manually dispatched")
     if not re.fullmatch(r"[0-9a-f]{40}", args.candidate):
         raise ValueError("full candidate SHA required")
     # Recheck reachability in the trusted checkout before obtaining the private key.
-    run("git", "merge-base", "--is-ancestor", args.candidate, "origin/main")
+    run("git", "merge-base", "--is-ancestor", args.candidate, "HEAD")
     sign(args.bundle, args.candidate, args.rc, args.output)
     print("Verified signatures for the complete source inventory")
 

--- a/scripts/test_sign_source_release.py
+++ b/scripts/test_sign_source_release.py
@@ -60,6 +60,70 @@ class SourceSigningTests(unittest.TestCase):
     def write_report(self):
         (self.bundle / "report.json").write_text(json.dumps(self.report))
 
+    def test_dispatch_from_release_branch(self):
+        repository = self.root / "repository"
+        repository.mkdir()
+        previous = Path.cwd()
+        try:
+            os.chdir(repository)
+            signing.run("git", "init", "-b", "main")
+            signing.run(
+                "git",
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.org",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "Initial",
+            )
+            signing.run("git", "checkout", "-b", "release/0.59.2")
+            signing.run(
+                "git",
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.org",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "Bump version",
+            )
+            candidate = signing.run("git", "rev-parse", "HEAD").decode().strip()
+            argv = [
+                "sign_source_release.py",
+                str(self.bundle),
+                candidate,
+                self.rc,
+                str(self.root / "signed"),
+            ]
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "GITHUB_REF": "refs/heads/release/0.59.2",
+                        "GITHUB_EVENT_NAME": "workflow_dispatch",
+                    },
+                ),
+                patch("sys.argv", argv),
+                patch.object(signing, "sign") as sign,
+            ):
+                signing.main()
+                sign.assert_called_once()
+                # The same candidate is not reachable when dispatching from main.
+                signing.run("git", "checkout", "main")
+                sign.reset_mock()
+                with self.assertRaises(RuntimeError):
+                    signing.main()
+                sign.assert_not_called()
+        finally:
+            os.chdir(previous)
+
     def test_complete_inventory(self):
         self.assertEqual(
             signing.validate(self.bundle, self.candidate, self.rc), self.files

--- a/website/community/release/ci-signing-proposal.md
+++ b/website/community/release/ci-signing-proposal.md
@@ -6,9 +6,8 @@ sidebar_position: 6
 # Source archive trusted publishing
 
 The manually dispatched `release-compose.yml` workflow prepares signed source
-candidates on Apache Trusted Releases (ATR). It remains disabled until ASF Security
-approves the workflow and the live GitHub/ATR configuration is verified. Normal CI
-continues to build unsigned archives. This workflow does not schedule releases,
+candidates on Apache Trusted Releases (ATR). A maintainer dispatch starts the
+build, signing and upload pipeline. Normal CI continues to build unsigned archives. This workflow does not schedule releases,
 start votes, finish releases, or publish language packages.
 
 ## Workflow boundary
@@ -41,7 +40,7 @@ mean ATR checks passed: inspect the candidate revision and check results in ATR.
 The upstream upload action is experimental; its pinned implementation must be
 reviewed again before upgrading.
 
-## Enablement
+## Prerequisites
 
 1. Send ASF Security the workflow and the reproduction evidence in
    [PR #8232](https://github.com/apache/opendal/pull/8232). Explain that reviewers
@@ -70,13 +69,22 @@ reviewed again before upgrading.
    | Vote workflows | Leave empty |
    | Finish workflows | Leave empty |
 
-5. Set the repository variable `SOURCE_RELEASE_ENABLED=true` only after these
-   prerequisites are verified. Leave it unset to keep compose disabled.
+## Trigger a candidate
 
-The repository secret's existence and the public key in KEYS have been verified.
-An authenticated end-to-end source upload and the live ATR configuration have not
-yet been verified by this PR. No Security or Infra request is sent by
-the workflow.
+Open the `Compose source candidate on ATR` workflow in GitHub Actions, select
+**Run workflow**, choose `main`, and enter the candidate commit SHA and RC version.
+No repository enablement switch or environment approval is required.
+
+Alternatively, set `CANDIDATE_SHA` and `RC_VERSION` to the reviewed commit and
+candidate version, then run:
+
+```bash
+gh workflow run release-compose.yml \
+  --repo apache/opendal \
+  --ref main \
+  -f candidate="$CANDIDATE_SHA" \
+  -f rc="$RC_VERSION"
+```
 
 ## Rehearsal and release handoff
 

--- a/website/community/release/ci-signing-proposal.md
+++ b/website/community/release/ci-signing-proposal.md
@@ -12,10 +12,12 @@ start votes, finish releases, or publish language packages.
 
 ## Workflow boundary
 
-Dispatch the workflow from `main` with a full reviewed candidate commit SHA and an
-`X.Y.Z-rc.N` candidate version. Initially, the candidate must be reachable from
-`main`, and its core package version must equal `X.Y.Z`. Candidate branches and
-automatic version selection require a separate extension.
+Dispatch the workflow from the release branch with a full reviewed candidate
+commit SHA and an `X.Y.Z-rc.N` candidate version. The candidate must be reachable
+from the workflow commit, and its core package version must equal `X.Y.Z`.
+Merge the version bump PR into the release branch before preparing the candidate.
+After the release succeeds, merge the release branch back into `main` to carry
+the version updates forward. Automatic version selection is not implemented.
 
 Three jobs separate credentials and responsibilities:
 
@@ -24,8 +26,9 @@ Three jobs separate credentials and responsibilities:
    immutable Actions artifact. It has neither signing secrets nor OIDC permission.
 2. The signing job downloads that artifact by ID, validates its
    commit, reproduction report, package inventory and SHA-512 checksums, and signs
-   only the expected `.tar.gz` files. Trusted tooling comes from the workflow's
-   `main` checkout; candidate scripts are not executed with the key. The public
+   only the expected `.tar.gz` files. Signing tooling comes from the workflow
+   commit on the selected branch and must be reviewed there. Candidate build
+   scripts run only in the build job, without the key. The public
    key must already be in OpenDAL KEYS. Each generated signature is verified
    against the configured primary fingerprint before the signed bundle is saved.
 3. The upload job downloads the signed bundle by ID and uses the commit-pinned
@@ -64,7 +67,7 @@ reviewed again before upgrading.
    | Setting | Value |
    | --- | --- |
    | Repository name | `opendal` |
-   | Repository branch | `main` |
+   | Repository branch | Leave empty to allow release branches |
    | Compose workflows | `.github/workflows/release-compose.yml` |
    | Vote workflows | Leave empty |
    | Finish workflows | Leave empty |
@@ -72,16 +75,17 @@ reviewed again before upgrading.
 ## Trigger a candidate
 
 Open the `Compose source candidate on ATR` workflow in GitHub Actions, select
-**Run workflow**, choose `main`, and enter the candidate commit SHA and RC version.
+**Run workflow**, choose the release branch, and enter the candidate commit SHA
+and RC version.
 No repository enablement switch or environment approval is required.
 
-Alternatively, set `CANDIDATE_SHA` and `RC_VERSION` to the reviewed commit and
-candidate version, then run:
+Alternatively, set `RELEASE_BRANCH`, `CANDIDATE_SHA` and `RC_VERSION` to the release
+branch, reviewed commit and candidate version, then run:
 
 ```bash
 gh workflow run release-compose.yml \
   --repo apache/opendal \
-  --ref main \
+  --ref "$RELEASE_BRANCH" \
   -f candidate="$CANDIDATE_SHA" \
   -f rc="$RC_VERSION"
 ```


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #8232 and #8234.

# Rationale for this change

A maintainer dispatch should start source candidate preparation without a separate enablement variable. Release branches need to carry version bumps through candidate preparation and publication before merging those updates back into main.

# What changes are included in this PR?

Remove SOURCE_RELEASE_ENABLED and the main-only checks. Validate that the candidate is reachable from the immutable workflow checkout in both build and signing jobs. Document release-branch dispatch, merging version updates back after release, and leaving ATR's optional repository branch setting empty.

# Are there any user-facing changes?

Maintainers can dispatch build, signing and ATR compose upload from a release branch. Signing tooling is taken from that branch's workflow commit and must be reviewed there. The apache/opendal repository restriction remains; the workflow does not start a vote or publish an official release.

# AI Usage Statement

AI assisted implementation, documentation and regression coverage. Local validation includes a release-branch-only candidate and rejection from an unrelated checkout. ATR settings were not changed and no release workflow was dispatched.
