### PR TITLE
fix(release): use dispatch commit for manual candidates

### DIFF
--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -43,29 +43,32 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - name: Select Friday cutoff and release baseline
+      - name: Select source commit and release baseline
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          cutoff=$(python3 - <<'PYTHON'
+          sha="$GITHUB_SHA"
+          if [ "$GITHUB_EVENT_NAME" = schedule ]; then
+            cutoff=$(python3 - <<'PYTHON'
           import datetime as d
           now = d.datetime.now(d.timezone.utc)
           friday = (now - d.timedelta(days=(now.weekday() - 4) % 7)).replace(hour=0, minute=0, second=0, microsecond=0)
           print(friday.strftime("%Y-%m-%dT%H:%M:%SZ"))
           PYTHON
-          )
-          # Push run timestamps record arrival on main, unlike commit dates.
-          sha=$(gh api --paginate --slurp 'repos/apache/opendal/actions/workflows/weekly_release.yml/runs?event=push&branch=main&per_page=100' |
-            jq -er --arg cutoff "$cutoff" '[.[].workflow_runs[] | select(.created_at <= $cutoff)] | max_by(.created_at, .id).head_sha // error("no push recorded before cutoff")')
+            )
+            # Push run timestamps record arrival on main, unlike commit dates.
+            sha=$(gh api --paginate --slurp 'repos/apache/opendal/actions/workflows/weekly_release.yml/runs?event=push&branch=main&per_page=100' |
+              jq -er --arg cutoff "$cutoff" '[.[].workflow_runs[] | select(.created_at <= $cutoff)] | max_by(.created_at, .id).head_sha // error("no push recorded before cutoff")')
+          fi
           baseline=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' "$sha")
           git checkout --detach "$sha"
           branch="release-candidates/weekly-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           {
-            echo "CUTOFF_SHA=$sha"
+            echo "SOURCE_SHA=$sha"
             echo "BASELINE=$baseline"
             echo "CANDIDATE_BRANCH=$branch"
           } >> "$GITHUB_ENV"
@@ -83,7 +86,7 @@ jobs:
           import os
           from pathlib import Path
           p = Path("CHANGELOG.md")
-          p.write_text(f"# v{os.environ['RC'].split('-rc.')[0]}\n\n- [Changes since {os.environ['BASELINE']}](https://github.com/apache/opendal/compare/{os.environ['BASELINE']}...{os.environ['CUTOFF_SHA']})\n\n" + p.read_text())
+          p.write_text(f"# v{os.environ['RC'].split('-rc.')[0]}\n\n- [Changes since {os.environ['BASELINE']}](https://github.com/apache/opendal/compare/{os.environ['BASELINE']}...{os.environ['SOURCE_SHA']})\n\n" + p.read_text())
           PYTHON
       - name: Push prepared candidate
         id: candidate
@@ -100,7 +103,7 @@ jobs:
             echo "sha=$(git rev-parse HEAD)"
             echo "rc=$RC"
           } >> "$GITHUB_OUTPUT"
-          echo "Prepared $RC on $CANDIDATE_BRANCH from cutoff $CUTOFF_SHA. Continuing to ATR compose." >> "$GITHUB_STEP_SUMMARY"
+          echo "Prepared $RC on $CANDIDATE_BRANCH from source $SOURCE_SHA. Continuing to ATR compose." >> "$GITHUB_STEP_SUMMARY"
 
   compose:
     needs: prepare

--- a/website/community/release/weekly.md
+++ b/website/community/release/weekly.md
@@ -7,7 +7,8 @@ sidebar_position: 4
 
 The weekly workflow prepares a release branch each Friday from the Friday
 00:00 UTC main cutoff and directly calls the existing `release-compose.yml` to
-build, sign and upload the candidate to ATR. Manual dispatch runs the same flow.
+build, sign and upload the candidate to ATR. Manual dispatch runs the same flow
+from the selected branch commit at the time of dispatch.
 Preparation creates no version PR and requires no manual merge.
 
 The release manager then follows the [release procedure](release.md) to verify
@@ -15,10 +16,12 @@ the candidate, start the vote and finish publication.
 
 ## Preparation
 
-The workflow selects the latest recorded main push at or before the cutoff.
+Scheduled runs select the latest recorded main push at or before the cutoff.
 Push-run timestamps record arrival on main; commit dates do not. Keep that run
 history until preparation finishes. The first week requires a recorded push before
-the cutoff. Manual dispatch uses the same cutoff and starts a fresh attempt.
+the cutoff. Manual dispatch starts a fresh attempt without requiring earlier push
+history. It uses the dispatch commit even if the branch advances while the run
+is queued.
 
 `update-version --patch` prepares at least a patch increment for each package from
 the latest reachable final release tag, preserving higher inventory versions and


### PR DESCRIPTION
# Which issue does this PR close?

Fixes the manual-run failure observed in [run 34092910269](https://github.com/apache/opendal/actions/runs/34092910269).

# Rationale for this change

Manual dispatch fails before preparation when no weekly push record exists before Friday's cutoff, including immediately after installing the workflow.

# What changes are included in this PR?

Use the dispatch SHA for manual runs, including checkout, so preparation works without prior push history and remains pinned if the branch advances while queued. Scheduled runs retain the Friday 00:00 UTC cutoff.

# Are there any user-facing changes?

Manual runs prepare from the selected branch at dispatch time. Documentation now distinguishes this from scheduled cutoff selection.

# AI Usage Statement

AI assisted diagnosis, implementation and local regression checks against the workflow's shell steps. GitHub run-list responses were simulated; no candidate was pushed or uploaded to ATR during validation.
