### PR TITLE
fix(release): install cargo-deny for weekly preparation

### DIFF
--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -47,6 +47,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup
+        with:
+          need-deny: true
       - name: Select source commit and release baseline
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Which issue does this PR close?

Fixes the preparation failure in [run 34099127367](https://github.com/apache/opendal/actions/runs/34099127367).

# Rationale for this change

Weekly preparation invokes `scripts/dependencies.py generate`, which requires `cargo-deny`. The runner does not install it by default and fails with `no such command: deny`.

# What changes are included in this PR?

Enable `need-deny` on the existing setup action, matching the dependency-check job.

# Are there any user-facing changes?

Weekly preparation installs its dependency-listing tool before generating the release dependency inventories.

# AI Usage Statement

AI assisted diagnosis and the workflow change. Workflow static validation passed; the corrected release run has not been executed against ATR.
