### PR TITLE
fix(services/hf): drop the trailing slash from the root tree URL

### DIFF
--- a/core/services/hf/src/core.rs
+++ b/core/services/hf/src/core.rs
@@ -1693,7 +1693,11 @@ mod uri {
             Self {
                 repo_type,
                 repo_id,
-                revision,
+                // An empty revision is no revision: `hf://datasets/user/repo@`
+                // and `revision=""` via options both reach here, and leaving
+                // `Some("")` in place would build URLs with an empty revision
+                // segment instead of falling back to `main`.
+                revision: revision.filter(|revision| !revision.is_empty()),
             }
         }
 
@@ -1839,11 +1843,7 @@ mod uri {
                 }
             } else if let Some((repo_id, rev)) = path.split_once('@') {
                 let rev = rev.replace("%2F", "/");
-                (
-                    repo_id.to_string(),
-                    if rev.is_empty() { None } else { Some(rev) },
-                    String::new(),
-                )
+                (repo_id.to_string(), Some(rev), String::new())
             } else {
                 (path, None, String::new())
             };
@@ -1932,21 +1932,27 @@ mod uri {
             recursive: bool,
             cursor: Option<&str>,
         ) -> String {
+            // HF answers a trailing slash with a 302 to the slash-less URL, so
+            // the separator lives in the segment rather than the template.
+            let path_segment = if self.path.is_empty() {
+                String::new()
+            } else {
+                format!("/{}", percent_encode_path(&self.path))
+            };
+
             let mut url = if self.repo.is_bucket() {
                 format!(
-                    "{}/api/buckets/{}/tree/{}?expand=True",
-                    endpoint,
-                    self.repo.repo_id,
-                    percent_encode_path(&self.path),
+                    "{}/api/buckets/{}/tree{}?expand=True",
+                    endpoint, self.repo.repo_id, path_segment,
                 )
             } else {
                 format!(
-                    "{}/api/{}/{}/tree/{}/{}?expand=True",
+                    "{}/api/{}/{}/tree/{}{}?expand=True",
                     endpoint,
                     self.repo.repo_type.as_plural_str(),
                     self.repo.repo_id,
                     percent_encode_revision(self.revision()),
-                    percent_encode_path(&self.path),
+                    path_segment,
                 )
             };
 
@@ -2215,6 +2221,76 @@ mod uri {
             let p = resolve("buckets/user/bucket");
             let url = p.repo.bucket_batch_url("https://huggingface.co");
             assert_eq!(url, "https://huggingface.co/api/buckets/user/bucket/batch");
+        }
+
+        #[test]
+        fn test_file_tree_url_root_has_no_trailing_slash() {
+            let p = resolve("datasets/user/repo");
+            assert_eq!(
+                p.file_tree_url("https://huggingface.co", false, None),
+                "https://huggingface.co/api/datasets/user/repo/tree/main?expand=True"
+            );
+        }
+
+        #[test]
+        fn test_file_tree_url_subdir_keeps_path_separator() {
+            let p = resolve("datasets/user/repo/data");
+            assert_eq!(
+                p.file_tree_url("https://huggingface.co", false, None),
+                "https://huggingface.co/api/datasets/user/repo/tree/main/data?expand=True"
+            );
+        }
+
+        #[test]
+        fn test_file_tree_url_encoded_revision_root() {
+            let p = resolve("datasets/user/repo@refs/convert/parquet");
+            assert_eq!(
+                p.file_tree_url("https://huggingface.co", false, None),
+                "https://huggingface.co/api/datasets/user/repo/tree/refs%2Fconvert%2Fparquet?expand=True"
+            );
+        }
+
+        /// Every construction site funnels through `HfRepo::new`, so an empty
+        /// revision from a URI or from `revision=""` in options is unset.
+        #[test]
+        fn test_empty_revision_is_unset() {
+            assert!(resolve("datasets/user/repo@").repo.revision.is_none());
+            assert!(
+                HfRepo::new(
+                    HfRepoType::Dataset,
+                    "user/repo".to_string(),
+                    Some(String::new()),
+                )
+                .revision
+                .is_none()
+            );
+        }
+
+        #[test]
+        fn test_file_tree_url_recursive_and_cursor() {
+            let p = resolve("datasets/user/repo");
+            assert_eq!(
+                p.file_tree_url("https://huggingface.co", true, Some("abc123")),
+                "https://huggingface.co/api/datasets/user/repo/tree/main?expand=True&recursive=True&cursor=abc123"
+            );
+        }
+
+        #[test]
+        fn test_bucket_file_tree_url_root_ends_at_tree() {
+            let p = resolve("buckets/user/bucket");
+            assert_eq!(
+                p.file_tree_url("https://huggingface.co", false, None),
+                "https://huggingface.co/api/buckets/user/bucket/tree?expand=True&recursive=false"
+            );
+        }
+
+        #[test]
+        fn test_bucket_file_tree_url_subdir_keeps_path_separator() {
+            let p = resolve("buckets/user/bucket/data");
+            assert_eq!(
+                p.file_tree_url("https://huggingface.co", false, None),
+                "https://huggingface.co/api/buckets/user/bucket/tree/data?expand=True&recursive=false"
+            );
         }
     }
 }

--- a/core/services/hf/src/lister.rs
+++ b/core/services/hf/src/lister.rs
@@ -210,7 +210,7 @@ mod tests {
 
         assert_eq!(
             mock_client.get_captured_url(),
-            "https://huggingface.co/api/models/test-user/test-repo/tree/main/?expand=True"
+            "https://huggingface.co/api/models/test-user/test-repo/tree/main?expand=True"
         );
         assert!(page_ctx.done);
         let entry = page_ctx.entries.pop_front().expect("entry must exist");


### PR DESCRIPTION
# Which issue does this PR close?

No existing issue. Found while testing #8225; independent of it.

# Rationale for this change

`HfUri::file_tree_url` always appends the path separator, so listing the repo root -- where the path is empty -- asks for `tree/main/` on a git repo and `tree/` on a bucket. HF answers both with a `302` to the slash-less URL, so every root listing pays an extra round trip on the rate-limited `/api` class and fails outright on a transport that does not follow redirects.

Verified live against huggingface.co:

| URL | status |
| --- | --- |
| `/api/datasets/<id>/tree/main/?expand=True` | 302 |
| `/api/datasets/<id>/tree/main?expand=True` | 200 |
| `/api/buckets/<id>/tree/?expand=True` | 302 |
| `/api/buckets/<id>/tree?expand=True` | 200 |
| `/api/datasets/<id>/tree/main/<subdir>?expand=True` | 200 |
| `/api/datasets/<id>/tree/refs%2Fconvert%2Fparquet/?expand=True` | 302 |
| `/api/datasets/<id>/tree/refs%2Fconvert%2Fparquet?expand=True` | 200 |

The encoded-revision rows confirm the fix holds where HF must decode `%2F` back into path segments to resolve the ref.

An empty revision reaches the same URL a second way: `revision()` falls back to `main` only for `None`, so `Some("")` builds `tree/`, or `tree//data` with a path. Both `hf://datasets/user/repo@` (via `HfUri::parse`) and `revision=""` in the options map (via `HfConfig::from_uri` and `HfBuilder::build`, which skip `parse`) produce it.

# What changes are included in this PR?

- Append the path separator only when the path is non-empty, covering the git-repo and bucket URL shapes.
- Normalize an empty revision to `None` in `HfRepo::new`, the constructor both paths above funnel through. This covers `via_iter` as well, which a fix in `HfUri::parse` would miss, and makes the guard in the sibling parse branch redundant.
- Pin the URL shapes with direct `file_tree_url` assertions beside the existing `test_bucket_*_url` tests: git and bucket roots, both subdirectory forms, an encoded revision, and the recursive/cursor query. The function is a pure string builder, so these need no mock transport. A separate test covers the empty-revision normalization.

# Are there any user-facing changes?

No API change. Root listings issue one request instead of two, and work on a transport that does not follow redirects. An empty revision now resolves to `main` instead of producing an empty revision segment.

# AI Usage Statement

- **Harness:** Claude Code
- **Model:** Claude Opus 5 (`claude-opus-5`)
- **Effort:** high
- **Role:** Found the redirect against the live API, wrote the fix and tests, and located the empty-revision route in review.

Unknowns that affect review: redirect behavior is confirmed against huggingface.co only for the URL shapes in the table. The `HfRepo::new` change is the most substantive edit and had no independent review pass.
