### PR TITLE
fix(website): dedupe theme-common to stop mobile navbar crash

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -118,6 +118,9 @@ const config = {
   ],
 
   plugins: [
+    // Keep a single @docusaurus/theme-common instance so navbar hooks share
+    // the same React context as theme-classic providers under pnpm.
+    require.resolve("./plugins/theme-common-singleton-plugin"),
     require.resolve("./plugins/specifications-docs-plugin"),
     [
       "@docusaurus/plugin-content-docs",

--- a/website/plugins/theme-common-singleton-plugin.js
+++ b/website/plugins/theme-common-singleton-plugin.js
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const path = require("path");
+
+/**
+ * pnpm can install multiple physical copies of @docusaurus/theme-common when
+ * peer dependency graphs diverge. Each copy creates its own React context, so
+ * swizzled navbar code that imports the package from the site root can call
+ * useNavbarMobileSidebar outside the NavbarMobileSidebarProvider that
+ * theme-classic mounted. Force one resolve path for the whole bundle.
+ */
+module.exports = function themeCommonSingletonPlugin() {
+  // package.json is not in "exports"; resolve the package entry then climb to root.
+  const themeCommonRoot = path.resolve(
+    path.dirname(require.resolve("@docusaurus/theme-common")),
+    "..",
+  );
+
+  return {
+    name: "theme-common-singleton-plugin",
+    configureWebpack() {
+      return {
+        resolve: {
+          alias: {
+            "@docusaurus/theme-common/internal": path.join(
+              themeCommonRoot,
+              "lib/internal.js",
+            ),
+            "@docusaurus/theme-common/Details": path.join(
+              themeCommonRoot,
+              "lib/components/Details/index.js",
+            ),
+            "@docusaurus/theme-common": themeCommonRoot,
+          },
+        },
+      };
+    },
+  };
+};


### PR DESCRIPTION
# Which issue does this PR close?

N/A — found while browsing; no existing issue matched `NavbarMobileSidebarProvider`.

# Rationale for this change

Shrinking the browser below the mobile breakpoint on https://opendal.apache.org/ crashes the page with:

> Hook z is called outside the `<NavbarMobileSidebarProvider>`.

Under pnpm, `@docusaurus/theme-common` can be installed twice when peer graphs diverge (here via different `postcss` versions). `theme-classic` mounts `NavbarMobileSidebarProvider` from one copy; swizzled MobileSidebar code calls `useNavbarMobileSidebar` from another. The React contexts do not match, so the hook throws when the mobile navbar mounts.

# What changes are included in this PR?

- Add `website/plugins/theme-common-singleton-plugin.js` to alias `@docusaurus/theme-common` (and its exported subpaths) to a single resolve path for the whole bundle.
- Register the plugin in `website/docusaurus.config.js`.

# Are there any user-facing changes?

Yes: the website no longer crashes when resizing to a mobile viewport; the mobile navbar drawer works again.

# AI Usage Statement

AI reproduced the production crash, traced it to duplicate `@docusaurus/theme-common` instances under pnpm, implemented the singleton alias plugin, and verified locally that homepage and `/docs/` survive desktop ↔ mobile resizes with the drawer usable. Assumption: forcing one resolve path in the bundler is sufficient even if pnpm still keeps two on-disk copies.

Made with [Cursor](https://cursor.com)