### PR TITLE
docs: specify AI usage configuration disclosure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,9 +33,15 @@ If there are any breaking changes to public APIs, please add the `breaking-chang
 # AI Usage Statement
 
 <!--
-If AI materially assisted this PR, briefly describe its role and disclose any
-assumptions or unknowns that affect review. Do not include routine command output
-or repeat information provided elsewhere.
+If AI materially assisted this PR, list each harness/model/effort combination
+that materially contributed, and briefly describe its role:
+
+- Harness: Application or agent framework used to run the model.
+- Model: Model name or identifier shown by the harness, with version if available.
+- Effort: Reasoning effort setting as named by the harness.
+- Role: AI's contribution and any assumptions or unknowns that affect review.
+
+Do not include routine command output or repeat information provided elsewhere.
 
 The author remains responsible for every submitted claim and change. If AI did
 not materially assist this PR, write "None".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,10 @@ policy.
   maintainer has explicitly accepted it as a hardening or maintenance goal.
 - A test against a fabricated response can verify implementation behavior, but
   it does not establish that the change solves a real-world problem.
-- In a Pull Request, briefly disclose AI's material role and any assumptions or
-  unknowns that affect review. Do not repeat routine validation output.
+- In a Pull Request, disclose each materially contributing harness, model, and
+  reasoning effort setting, along with AI's role and any assumptions or unknowns
+  that affect review. Follow the AI Usage Statement requirements in
+  CONTRIBUTING.md. Do not repeat routine validation output.
 
 The human contributor remains responsible for every submitted claim and change.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,22 @@ guides the work and remains accountable for it.
 The contributor, not the AI tool, is responsible for the accuracy, relevance,
 and quality of every submission.
 
+### AI Usage Statement
+
+If AI materially assisted a Pull Request, include the following in its AI Usage
+Statement:
+
+- **Harness:** The application or agent framework used to run the model.
+- **Model:** The model name or identifier shown by the harness, including its
+  version when available.
+- **Effort:** The reasoning effort setting used, as named by the harness.
+- **Role:** How AI contributed, and any assumptions or unknowns that affect
+  review.
+
+List each harness, model, and effort combination that materially contributed.
+Keep the statement brief and omit routine command output or information already
+provided elsewhere. If AI did not materially assist the PR, write `None`.
+
 ### Bug Reports
 
 OpenDAL welcomes the use of AI tools to analyze source code and find bugs. A


### PR DESCRIPTION
# Which issue does this PR close?

No linked issue; this clarifies the existing contribution policy.

# Rationale for this change

The AI Usage Statement currently asks contributors to describe AI's role but does not identify the harness, model, or reasoning effort used. Recording these makes the disclosure more informative.

# What changes are included in this PR?

Require the harness, model, reasoning effort, and AI's role in the contribution guide and PR template, and align the agent instructions with these requirements.

# Are there any user-facing changes?

Contributors are asked to include the AI configuration in their PR disclosure. No library behavior changes.

# AI Usage Statement

- Harness: Codex desktop.
- Model: gpt-6-astra.
- Effort: medium.
- Role: AI drafted the documentation changes and PR description under human direction. The contributor reviewed the requirements and requested submission.
