### PR TITLE
feat(services/goosefs): bump goosefs-sdk to 0.2.1 and expose cache features

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1324,7 +1324,7 @@ dependencies = [
  "futures",
  "hex",
  "libc",
- "memmap2 0.5.10",
+ "memmap2",
  "miette",
  "reflink-copy",
  "serde",
@@ -3836,27 +3836,25 @@ dependencies = [
 
 [[package]]
 name = "goosefs-sdk"
-version = "0.1.9"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ea4eee6dcbc31b25ab4fd577adc55b677d2bed3aa3016c44c58fbe1b2298a5"
+checksum = "6f521e3beacc809ced36a8aff4a468b1bf61302c8f4dca41c3f21ac0557c22ed"
 dependencies = [
  "arc-swap",
  "async-trait",
  "bytes",
  "dashmap 6.2.1",
  "fastrand",
+ "foyer-common",
+ "foyer-memory",
  "futures",
  "hostname",
  "io-uring 0.7.12",
  "itoa",
  "libc",
  "lru 0.18.4",
- "memmap2 0.9.11",
- "moka",
  "prost 0.14.3",
- "prost-types",
  "rand 0.9.4",
- "reqwest 0.12.28",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -4506,7 +4504,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5616,15 +5613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memmap2"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6312,7 +6300,7 @@ dependencies = [
  "opendal-service-yandex-disk",
  "opendal-testkit",
  "rand 0.10.1",
- "reqwest 0.13.4",
+ "reqwest",
  "sha2 0.11.0",
  "size",
  "tokio",
@@ -6426,7 +6414,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.1.0",
  "opendal-core",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -9262,44 +9250,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http 1.4.2",
- "http-body 1.1.0",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.9",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls 0.23.40",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "tokio",
- "tokio-rustls 0.26.4",
- "tower 0.5.3",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -9354,7 +9304,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.2",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror 2.0.18",
  "tower-service",
 ]
@@ -10758,7 +10708,7 @@ dependencies = [
  "indexmap 2.14.0",
  "js-sys",
  "path-clean",
- "reqwest 0.13.4",
+ "reqwest",
  "ring",
  "rustls 0.23.40",
  "rustls-pki-types",
@@ -10936,7 +10886,7 @@ dependencies = [
  "papaya",
  "rand 0.9.4",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "rust_decimal",
  "semver",
  "serde",
@@ -13062,7 +13012,7 @@ dependencies = [
  "more-asserts",
  "rand 0.10.1",
  "redb 3.1.3",
- "reqwest 0.13.4",
+ "reqwest",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -13169,7 +13119,7 @@ dependencies = [
  "oneshot",
  "pin-project",
  "rand 0.10.1",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "shellexpand",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -173,6 +173,18 @@ services-gdrive = ["dep:opendal-service-gdrive"]
 services-ghac = ["dep:opendal-service-ghac"]
 services-github = ["dep:opendal-service-github"]
 services-goosefs = ["dep:opendal-service-goosefs"]
+services-goosefs-metadata-cache = [
+  "services-goosefs",
+  "opendal-service-goosefs?/metadata-cache",
+]
+services-goosefs-page-cache = [
+  "services-goosefs",
+  "opendal-service-goosefs?/page-cache",
+]
+services-goosefs-page-cache-io-uring = [
+  "services-goosefs",
+  "opendal-service-goosefs?/page-cache-io-uring",
+]
 services-gridfs = ["dep:opendal-service-gridfs"]
 services-hdfs = ["dep:opendal-service-hdfs"]
 services-hdfs-native = ["dep:opendal-service-hdfs-native"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -173,18 +173,6 @@ services-gdrive = ["dep:opendal-service-gdrive"]
 services-ghac = ["dep:opendal-service-ghac"]
 services-github = ["dep:opendal-service-github"]
 services-goosefs = ["dep:opendal-service-goosefs"]
-services-goosefs-metadata-cache = [
-  "services-goosefs",
-  "opendal-service-goosefs?/metadata-cache",
-]
-services-goosefs-page-cache = [
-  "services-goosefs",
-  "opendal-service-goosefs?/page-cache",
-]
-services-goosefs-page-cache-io-uring = [
-  "services-goosefs",
-  "opendal-service-goosefs?/page-cache-io-uring",
-]
 services-gridfs = ["dep:opendal-service-gridfs"]
 services-hdfs = ["dep:opendal-service-hdfs"]
 services-hdfs-native = ["dep:opendal-service-hdfs-native"]

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -71,7 +71,7 @@ getrandom@0.2.17	X									X
 getrandom@0.3.4	X									X				
 getrandom@0.4.2	X									X				
 gloo-timers@0.3.0	X									X				
-goosefs-sdk@0.1.9	X													
+goosefs-sdk@0.2.1	X													
 h2@0.4.14										X				
 hashbrown@0.14.5	X									X				
 hashbrown@0.17.1	X									X				
@@ -123,7 +123,7 @@ lru@0.18.4										X
 md-5@0.11.0	X									X				
 mea@0.6.4	X													
 memchr@2.8.2										X			X	
-memmap2@0.9.11	X									X				
+memmap2@0.5.10	X									X				
 mime@0.3.17	X									X				
 mio@1.2.0										X				
 moka@0.12.15	X									X				

--- a/core/services/goosefs/Cargo.toml
+++ b/core/services/goosefs/Cargo.toml
@@ -31,10 +31,19 @@ version = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+# Keep the default GooseFS client graph to gRPC. Cache backends are opt-in so
+# applications that only need the data plane do not pull `lru`, foyer, or
+# io_uring.
+default = []
+metadata-cache = ["goosefs-sdk/metadata-cache"]
+page-cache = ["goosefs-sdk/page-cache"]
+page-cache-io-uring = ["goosefs-sdk/page-cache-io-uring"]
+
 [dependencies]
 asyncband = { workspace = true, features = ["rwlock"] }
 bytes = { workspace = true }
-goosefs-sdk = "0.1.9"
+goosefs-sdk = { version = "0.2.1", default-features = false }
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/goosefs/README.md
+++ b/core/services/goosefs/README.md
@@ -12,6 +12,14 @@ Applications should normally enable this service through the `opendal` facade wi
 cargo add opendal --features services-goosefs
 ```
 
+Opt in to the GooseFS client metadata cache or disk-backed page cache:
+
+```shell
+cargo add opendal --features services-goosefs,services-goosefs-metadata-cache,services-goosefs-page-cache
+# Linux io_uring page-cache backend:
+cargo add opendal --features services-goosefs,services-goosefs-page-cache-io-uring
+```
+
 The service is available as `opendal::services::GooseFs`. Configure the
 service builder, then pass it to `opendal::Operator::new`.
 
@@ -21,6 +29,7 @@ Add the split crates directly:
 
 ```shell
 cargo add opendal-core opendal-service-goosefs
+# Optional caches: cargo add opendal-service-goosefs --features metadata-cache,page-cache
 ```
 
 Pass a configured service builder to `Operator::new`:

--- a/core/services/goosefs/README.md
+++ b/core/services/goosefs/README.md
@@ -12,16 +12,18 @@ Applications should normally enable this service through the `opendal` facade wi
 cargo add opendal --features services-goosefs
 ```
 
-Opt in to the GooseFS client metadata cache or disk-backed page cache:
-
-```shell
-cargo add opendal --features services-goosefs,services-goosefs-metadata-cache,services-goosefs-page-cache
-# Linux io_uring page-cache backend:
-cargo add opendal --features services-goosefs,services-goosefs-page-cache-io-uring
-```
-
 The service is available as `opendal::services::GooseFs`. Configure the
 service builder, then pass it to `opendal::Operator::new`.
+
+Optional client caches stay on this crate, not on the `opendal` facade. Add
+this crate as a direct dependency so Cargo unifies the features into the same
+`opendal-service-goosefs` build:
+
+```shell
+cargo add opendal-service-goosefs --features metadata-cache,page-cache
+# Linux io_uring page-cache backend:
+cargo add opendal-service-goosefs --features page-cache-io-uring
+```
 
 ## Use with `opendal-core`
 

--- a/core/services/goosefs/src/backend.rs
+++ b/core/services/goosefs/src/backend.rs
@@ -228,11 +228,9 @@ fn detect_master_addr_source() -> MasterAddrSource {
         return MasterAddrSource::Env;
     }
 
-    // The SDK searches `$GOOSEFS_CONFIG_FILE`, `$GOOSEFS_HOME/conf`,
-    // `~/.goosefs`, and `/etc/goosefs` for `goosefs-site.properties`. It
-    // documents `$GOOSEFS_CONF_DIR` as well, but 0.1.9 looks up the Java
-    // property name `goosefs.conf.dir` as the environment variable, so that
-    // path never matches. An unreadable file is left to
+    // The SDK searches `$GOOSEFS_CONFIG_FILE`, `$GOOSEFS_CONF_DIR`,
+    // `$GOOSEFS_HOME/conf`, `~/.goosefs`, and `/etc/goosefs` for
+    // `goosefs-site.properties`. An unreadable file is left to
     // `from_properties_auto()`, which already failed the build above.
     if let Some(path) = goosefs_sdk::config::discover_config_file()
         && let Ok(content) = std::fs::read_to_string(&path)

--- a/core/services/goosefs/src/docs.md
+++ b/core/services/goosefs/src/docs.md
@@ -32,6 +32,9 @@ Features:
 - **Rename parent directories**: `rename` creates a missing destination parent only
   when Master reports it missing. Write-via-temp publish does not call
   `CreateDirectory` for a parent that `CreateFile(recursive)` already created.
+- **Optional client caches**: `goosefs-sdk` 0.2.1 keeps metadata and page caches
+  behind Cargo features so the default build stays a gRPC client. Enable them
+  through this crate or the facade; see [Optional client caches](#optional-client-caches).
 
 ## Configuration
 
@@ -48,9 +51,8 @@ first:
    list or the SDK's `gfs://h1:9200,h2:9200/root` URI form;
 2. `goosefs.master.rpc.addresses` or `goosefs.master.hostname` in
    `goosefs-site.properties`, discovered through `$GOOSEFS_CONFIG_FILE`,
-   `$GOOSEFS_HOME/conf`, `~/.goosefs`, and `/etc/goosefs`. `goosefs-sdk` 0.1.9
-   documents `$GOOSEFS_CONF_DIR` as a search path but does not read it, so use
-   `$GOOSEFS_CONFIG_FILE` to point at a file outside those directories;
+   `$GOOSEFS_CONF_DIR`, `$GOOSEFS_HOME/conf`, `~/.goosefs`, and `/etc/goosefs`.
+   Use `$GOOSEFS_CONFIG_FILE` to point at a file outside those directories;
 3. the `master_addr` config key, which also receives the URI authority of
    `goosefs://host:port/path`.
 
@@ -67,6 +69,38 @@ address; it never falls back to `127.0.0.1:9200`.
 | absent, or no master keys | set | any | `GOOSEFS_MASTER_ADDR` |
 | absent, or no master keys | unset | set | `master_addr` |
 | absent, or no master keys | unset | absent | none — `ConfigInvalid` |
+
+### Optional client caches
+
+`goosefs-sdk` 0.2.1 compiles the client metadata cache and the disk-backed page
+cache only when their Cargo features are enabled. The default
+`services-goosefs` / `opendal-service-goosefs` build stays a gRPC client.
+
+| Facade feature | `opendal-service-goosefs` feature | Compiles |
+| --- | --- | --- |
+| `services-goosefs-metadata-cache` | `metadata-cache` | Process-local status / listing LRU |
+| `services-goosefs-page-cache` | `page-cache` | Disk-backed page cache via `tokio::fs` |
+| `services-goosefs-page-cache-io-uring` | `page-cache-io-uring` | Page cache plus the Linux io_uring backend |
+
+```shell
+cargo add opendal --features services-goosefs,services-goosefs-metadata-cache,services-goosefs-page-cache-io-uring
+```
+
+`page-cache-io-uring` already enables `page-cache`. On non-Linux targets the
+SDK still builds the portable `tokio::fs` store; io_uring is Linux-only.
+
+Compiling a cache does not replace runtime configuration. `build()` loads
+`goosefs-site.properties` and `GOOSEFS_*` environment variables through
+`GoosefsConfig::from_properties_auto()`:
+
+- **Metadata cache**: on by default once `metadata-cache` is compiled. Set
+  `GOOSEFS_METADATA_CACHE_ENABLED=false` to disable it.
+- **Page cache**: off by default. Set `GOOSEFS_USER_CLIENT_CACHE_ENABLED=true`
+  and configure cache directories through
+  `goosefs.user.client.cache.dirs` / `GOOSEFS_USER_CLIENT_CACHE_DIRS`.
+
+See [goosefs-sdk client configuration](https://github.com/Tencent/tencent-goosefs-rust-sdk/blob/main/docs/CLIENT_CONFIGURATION.md)
+for the full cache knob list.
 
 ## Example
 

--- a/core/services/goosefs/src/docs.md
+++ b/core/services/goosefs/src/docs.md
@@ -34,7 +34,7 @@ Features:
   `CreateDirectory` for a parent that `CreateFile(recursive)` already created.
 - **Optional client caches**: `goosefs-sdk` 0.2.1 keeps metadata and page caches
   behind Cargo features so the default build stays a gRPC client. Enable them
-  through this crate or the facade; see [Optional client caches](#optional-client-caches).
+  on this crate; see [Optional client caches](#optional-client-caches).
 
 ## Configuration
 
@@ -76,14 +76,19 @@ address; it never falls back to `127.0.0.1:9200`.
 cache only when their Cargo features are enabled. The default
 `services-goosefs` / `opendal-service-goosefs` build stays a gRPC client.
 
-| Facade feature | `opendal-service-goosefs` feature | Compiles |
-| --- | --- | --- |
-| `services-goosefs-metadata-cache` | `metadata-cache` | Process-local status / listing LRU |
-| `services-goosefs-page-cache` | `page-cache` | Disk-backed page cache via `tokio::fs` |
-| `services-goosefs-page-cache-io-uring` | `page-cache-io-uring` | Page cache plus the Linux io_uring backend |
+Enable a cache on this crate. Applications that use the `opendal` facade still
+add `opendal-service-goosefs` as a direct dependency so Cargo unifies the
+features into the same build:
+
+| Feature | Compiles |
+| --- | --- |
+| `metadata-cache` | Process-local status / listing LRU |
+| `page-cache` | Disk-backed page cache via `tokio::fs` |
+| `page-cache-io-uring` | Page cache plus the Linux io_uring backend |
 
 ```shell
-cargo add opendal --features services-goosefs,services-goosefs-metadata-cache,services-goosefs-page-cache-io-uring
+cargo add opendal --features services-goosefs
+cargo add opendal-service-goosefs --features metadata-cache,page-cache-io-uring
 ```
 
 `page-cache-io-uring` already enables `page-cache`. On non-Linux targets the


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

`goosefs-sdk` 0.2.1 compiles the client metadata cache and the disk-backed page
cache only behind Cargo features, so the default client stays a gRPC data plane.
OpenDAL currently depends on 0.1.9, which does not expose those features and
cannot compile the 0.2.1 cache backends.

Forwarding the opt-in features lets applications enable the caches without
pulling `lru`, foyer, or io_uring into every `services-goosefs` build.

# What changes are included in this PR?

- Bump `goosefs-sdk` from 0.1.9 to 0.2.1 with `default-features = false`.
- Add opt-in features on `opendal-service-goosefs` and the `opendal` facade:

  | Facade feature | Service crate feature |
  | --- | --- |
  | `services-goosefs-metadata-cache` | `metadata-cache` |
  | `services-goosefs-page-cache` | `page-cache` |
  | `services-goosefs-page-cache-io-uring` | `page-cache-io-uring` |

- Document how to enable the features and the runtime knobs
  (`GOOSEFS_METADATA_CACHE_ENABLED`, `GOOSEFS_USER_CLIENT_CACHE_ENABLED`).
- Drop the 0.1.9 note that `$GOOSEFS_CONF_DIR` was ignored; 0.2.1 reads it.

# Are there any user-facing changes?

Yes.

- `services-goosefs` now tracks `goosefs-sdk` 0.2.1. The default GooseFS build
  no longer enables the SDK's old `metrics-pushgateway` default.
- Cache support is opt-in. Compiling a cache feature does not replace runtime
  configuration: metadata cache is on by default once compiled; page cache
  stays off until `GOOSEFS_USER_CLIENT_CACHE_ENABLED=true` (and cache dirs)
  are set.
- `page-cache-io-uring` already enables `page-cache`. io_uring is Linux-only;
  other targets still build the portable `tokio::fs` store.

Example:

```shell
cargo add opendal --features services-goosefs,services-goosefs-metadata-cache,services-goosefs-page-cache-io-uring