### PR TITLE
fix(bindings/python): sync File stub with GIL-release docstring

### DIFF
--- a/bindings/python/python/opendal/file.pyi
+++ b/bindings/python/python/opendal/file.pyi
@@ -163,6 +163,9 @@ class File:
     A file-like object for reading and writing data.
 
     Created by the `open` method of the `Operator` class.
+
+    Storage I/O releases the Python GIL while waiting. Concurrent operations on
+    the same file are rejected; use separate files for I/O from multiple threads.
     """
 
     def __enter__(self, /) -> File: ...


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #8267. Does not close a new issue.

# Rationale for this change

#8267 documented that blocking `File` I/O releases the Python GIL, but did
not regenerate `bindings/python/python/opendal/file.pyi`. Python CI runs
`just stub-gen` and then `git diff --exit-code`, so any PR that touches
`core/**` now fails that check even when it does not change Python
bindings.

# What changes are included in this PR?

Update the `File` class docstring in `file.pyi` to match the rustdoc on
`opendal.file.File`:

- Storage I/O releases the Python GIL while waiting.
- Concurrent operations on the same file are rejected; use separate files
  for I/O from multiple threads.

# Are there any user-facing changes?

The committed type stub now matches the runtime class docstring. Behavior
is unchanged.

# AI Usage Statement

- Harness: Cursor
- Effort: default
- Role: identified the stale stub as a follow-up to #8267 (not caused by
  unrelated `core/**` PRs) and synced `file.pyi` to the generated
  docstring. Did not re-run `just stub-gen`; the change matches the CI
  `git diff` output.