### PR TITLE
fix(core): skip pointer-width-dependent layout tests on 32-bit targets

### DIFF
--- a/core/core/src/raw/ops.rs
+++ b/core/core/src/raw/ops.rs
@@ -1520,6 +1520,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn compact_operation_layouts() {
         assert_eq!(size_of::<OpRead>(), 16);
         assert_eq!(size_of::<OpStat>(), 16);

--- a/core/core/src/types/metadata.rs
+++ b/core/core/src/types/metadata.rs
@@ -743,6 +743,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn metadata_layout_is_40_bytes() {
         assert_eq!(size_of::<MetadataHeader>(), 24);
         assert_eq!(size_of::<CompactValues>(), 16);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #8273.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

CompactValues wraps Option<Arc<[u8]>>, a fat pointer that is 16 bytes on 64-bit targets but only 8 bytes on 32-bit targets like i686, which breaks the hardcoded size_of assertions in compact_operation_layouts and metadata_layout_is_40_bytes.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix for running tests on i686

# Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If AI materially assisted this PR, list each harness/model/effort combination
that materially contributed, and briefly describe its role:

- Harness: Application or agent framework used to run the model.
- Model: Model name or identifier shown by the harness, with version if available.
- Effort: Reasoning effort setting as named by the harness.
- Role: AI's contribution and any assumptions or unknowns that affect review.

Do not include routine command output or repeat information provided elsewhere.

The author remains responsible for every submitted claim and change. If AI did
not materially assist this PR, write "None".
-->
None