### PR TITLE
fix(release): repair weekly signing, dispatch and RC numbering

### DIFF
--- a/.agents/skills/opendal-release/references/rc.md
+++ b/.agents/skills/opendal-release/references/rc.md
@@ -8,7 +8,10 @@ Read `website/community/release/weekly.md` and the selected revision of
 `.github/workflows/weekly_release.yml` before operating this path. Scheduled
 preparation uses the Friday cutoff; manual dispatch pins the selected commit.
 The workflow prepares package versions, pushes a candidate branch and lightweight
-RC tag, and calls `release-compose.yml` to build, sign and upload source archives.
+RC tag with the first unused `rc.N` number for its version, and calls
+`release-compose.yml` to build, sign and upload source archives. Signing accepts
+both schedule and manual dispatch events. Disabled downstream workflows are
+skipped and listed in the run summary.
 Do not add a manual version PR or rebuild an already staged candidate by default.
 
 Check that the dispatch implementation is on the revision actually running.

--- a/.github/workflows/weekly_release.yml
+++ b/.github/workflows/weekly_release.yml
@@ -82,7 +82,12 @@ jobs:
           done < <(git ls-files '*Cargo.lock')
           python3 scripts/dependencies.py generate
           version=$(cargo run --quiet --manifest-path dev/Cargo.toml -- release-packages | jq -er '.[] | select(.path == "core") | .version')
-          export RC="$version-rc.$((GITHUB_RUN_ID * 1000 + GITHUB_RUN_ATTEMPT))"
+          # Choose the first unused RC number, including manually prepared tags.
+          rc_number=1
+          while git show-ref --verify --quiet "refs/tags/v$version-rc.$rc_number"; do
+            rc_number=$((rc_number + 1))
+          done
+          export RC="$version-rc.$rc_number"
           echo "RC=$RC" >> "$GITHUB_ENV"
           python3 - <<'PYTHON'
           import os
@@ -133,7 +138,14 @@ jobs:
           SHA: ${{ needs.prepare.outputs.sha }}
         run: |
           # GITHUB_TOKEN pushes do not trigger the existing tag workflows.
-          for workflow in ci_bindings_{c,cpp,d,dart,dotnet,go,haskell,java,lua,nodejs,ocaml,php,ruby,swift,zig}.yml release_{dart,dotnet,java,nodejs,python,ruby,rust}.yml docs.yml; do
+          for workflow in ci_bindings_{c,cpp,d,dart,dotnet,go,haskell,java,lua,moonbit,nodejs,ocaml,php,ruby,swift,zig}.yml release_{dart,dotnet,java,nodejs,python,ruby,rust}.yml docs.yml; do
+            state=$(gh api "repos/apache/opendal/actions/workflows/$workflow" --jq .state)
+            case "$state" in
+              disabled_*)
+                echo "Skipped $workflow ($state)." >> "$GITHUB_STEP_SUMMARY"
+                continue
+                ;;
+            esac
             # Reuse runs already accepted before a partial dispatch failure.
             count=$(gh run list --repo apache/opendal --workflow "$workflow" --commit "$SHA" --event workflow_dispatch --limit 1 --json databaseId --jq length)
             if [ "$count" -gt 0 ]; then continue; fi

--- a/scripts/sign_source_release.py
+++ b/scripts/sign_source_release.py
@@ -176,8 +176,8 @@ def main():
     parser.add_argument("rc")
     parser.add_argument("output", type=Path)
     args = parser.parse_args()
-    if os.environ.get("GITHUB_EVENT_NAME") != "workflow_dispatch":
-        raise ValueError("source signing must be manually dispatched")
+    if os.environ.get("GITHUB_EVENT_NAME") not in {"workflow_dispatch", "schedule"}:
+        raise ValueError("source signing requires manual dispatch or a scheduled run")
     if not re.fullmatch(r"[0-9a-f]{40}", args.candidate):
         raise ValueError("full candidate SHA required")
     # Recheck reachability in the trusted checkout before obtaining the private key.

--- a/scripts/test_sign_source_release.py
+++ b/scripts/test_sign_source_release.py
@@ -60,7 +60,7 @@ class SourceSigningTests(unittest.TestCase):
     def write_report(self):
         (self.bundle / "report.json").write_text(json.dumps(self.report))
 
-    def test_dispatch_from_release_branch(self):
+    def test_signing_entrypoint_events_and_reachability(self):
         repository = self.root / "repository"
         repository.mkdir()
         previous = Path.cwd()
@@ -113,8 +113,23 @@ class SourceSigningTests(unittest.TestCase):
                 patch("sys.argv", argv),
                 patch.object(signing, "sign") as sign,
             ):
-                signing.main()
-                sign.assert_called_once()
+                for event in ("workflow_dispatch", "schedule"):
+                    with self.subTest(event=event), patch.dict(
+                        os.environ, {"GITHUB_EVENT_NAME": event}
+                    ):
+                        sign.reset_mock()
+                        signing.main()
+                        sign.assert_called_once_with(
+                            self.bundle, candidate, self.rc, self.root / "signed"
+                        )
+                for event in ("push", "pull_request", "pull_request_target", ""):
+                    with self.subTest(event=event), patch.dict(
+                        os.environ, {"GITHUB_EVENT_NAME": event}
+                    ):
+                        sign.reset_mock()
+                        with self.assertRaisesRegex(ValueError, "scheduled run"):
+                            signing.main()
+                        sign.assert_not_called()
                 # The same candidate is not reachable when dispatching from main.
                 signing.run("git", "checkout", "main")
                 sign.reset_mock()

--- a/website/community/release/weekly.md
+++ b/website/community/release/weekly.md
@@ -33,7 +33,11 @@ Each attempt commits the version, dependency and changelog updates on a fresh
 `release-candidates/weekly-<run>-<attempt>` branch. It pushes that branch and its RC
 lightweight tag together, then passes the resulting SHA to compose in the same workflow run.
 Compose signs the source archives; the lightweight tag itself is unsigned.
-The RC suffix identifies the Actions run and attempt. Compatibility or preparation
+RC tags use `v<version>-rc.1`, `rc.2`, and so on. Preparation chooses the first
+unused positive RC number for that version from the fetched tags, including
+manual candidates. Existing tags are preserved, including legacy tags whose
+suffix contains an Actions run ID. The candidate branch retains the run and
+attempt for traceability. A conflicting tag push fails without replacing the tag. Compatibility or preparation
 failures stop the run before compose; correct the cause and start another run.
 
 Preparing a new candidate does not cancel an existing vote or replace approved
@@ -43,6 +47,7 @@ another vote. Abandoned branches and ATR drafts can be cleaned up separately.
 ## Configuration
 
 Reuse the existing `GPG_SECRET_KEY` secret and `SOURCE_SIGNING_FINGERPRINT` variable.
+Source signing accepts both scheduled and manually dispatched runs.
 Register the weekly workflow for ATR compose OIDC, since the reusable workflow
 retains its caller's identity. The actor initiating a manual run or owning the
 schedule must have the required ASF-linked project permissions. An RM should
@@ -56,7 +61,8 @@ not trigger downstream push workflows for tags created with `GITHUB_TOKEN`.
 These dispatches retain the RC behavior: Java stages to Nexus, Python uses
 TestPyPI, NodeJS performs a publish dry run, Ruby and .NET retain artifacts, and
 Rust does not publish. Documentation retains RC staging without deploying to
-nightlies. A retry skips workflows already dispatched for the candidate commit;
+nightlies. Disabled workflows are skipped and recorded in the run summary.
+A retry skips workflows already dispatched for the candidate commit;
 rerun failed downstream jobs from their own runs.
 
 After ATR upload and dispatch succeed, the workflow posts a candidate preparation


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #8241 and the [failed scheduled run on September 11](https://github.com/apache/opendal/actions/runs/34548424894).

# Rationale for this change

Weekly preparation succeeded, but signing rejected the `schedule` event and downstream dispatch stopped at the manually disabled D workflow. Source upload and the candidate notice were therefore skipped. RC suffixes derived from Actions run IDs also made candidates difficult to identify.

# What changes are included in this PR?

- Select the first unused positive `rc.N` tag for each version, preserving existing tags, including legacy run-ID suffixes.
- Accept scheduled and manually dispatched signing, with entrypoint regression coverage for allowed events, rejected events and candidate reachability.
- Skip disabled workflows and record them in the run summary; retain failure reporting for other dispatch errors. Include the new MoonBit tag workflow in the dispatch list.
- Update the weekly release guide and release skill.

# Are there any user-facing changes?

New candidates use readable tags such as `v0.59.2-rc.1`. Disabled workflows no longer prevent later release builds from starting. Existing candidate tags are unchanged.

# AI Usage Statement

- Harness: Codex desktop.
- Model: GPT-6; the exact variant is not exposed in this session.
- Effort: Not exposed in this session.
- Role: Diagnosed the live failure, implemented the fixes and documentation, and validated signing, RC allocation with a temporary Git repository, and dispatch behavior with a local CLI substitute. Scheduled signing and dispatch with the repository workflow token still need remote validation after merge; this change does not recover the existing failed run by itself.
