### PR TITLE
fix(release): ship root CHANGELOG in source archives

### DIFF
--- a/dev/src/release/mod.rs
+++ b/dev/src/release/mod.rs
@@ -121,7 +121,16 @@ pub fn archive_package(sign: bool) -> anyhow::Result<()> {
     let packages = package::all_packages();
     for package in packages {
         let mut cmd = find_command("git", &workspace_dir);
-        cmd.args(["ls-files", "--stage", "-z", "--", "LICENSE", "NOTICE"]);
+        // Package symlinks point at these root files, so every archive ships them.
+        cmd.args([
+            "ls-files",
+            "--stage",
+            "-z",
+            "--",
+            "LICENSE",
+            "NOTICE",
+            "CHANGELOG.md",
+        ]);
         cmd.arg(package.name());
         for dep in package.dependencies() {
             cmd.arg(dep.name());

--- a/website/community/release/reproducible-source.md
+++ b/website/community/release/reproducible-source.md
@@ -21,8 +21,8 @@ local source edits therefore change the release bytes. It does not regenerate
 source files as part of packaging.
 
 The source package inventory comes from `dev/src/release/package.rs`. Each archive
-includes the package, its declared source dependencies, and the root LICENSE and
-NOTICE files. Paths are sorted. Tar entries use timestamp zero, numeric owner and
+includes the package, its declared source dependencies, and the root LICENSE,
+NOTICE and CHANGELOG.md files. Paths are sorted. Tar entries use timestamp zero, numeric owner and
 group zero, empty owner/group names, and Git's regular/executable file modes.
 Symlinks retain their link target and are not followed. Gzip includes neither a
 filename nor a timestamp. The checked-in `dev/Cargo.lock` fixes the compression


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The 0.59.2-rc.1 source archives do not build. `core/core/src/docs/mod.rs` includes `../../CHANGELOG.md`, which is the `core/core/CHANGELOG.md` symlink to the root `CHANGELOG.md` (#8223).

Since #8232 the packager keeps symlinks as links instead of following them, but it only ships the root `LICENSE` and `NOTICE`, so every archive that includes `core` has a dangling `CHANGELOG.md` link:

```
error: couldn't read `core/src/docs/../../CHANGELOG.md`: No such file or directory
  --> core/src/docs/mod.rs:34:9
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Ship the root `CHANGELOG.md` in every source archive, alongside `LICENSE` and `NOTICE`, and document it in `reproducible-source.md`.

# Are there any user-facing changes?

Source archives now contain the root `CHANGELOG.md`, and `core` builds from the extracted archive again.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

# Breaking changes

None

<!--
Leave this section empty for compatible changes. For breaking changes, add the
breaking-changes label and use the following format outside this comment:

Affected packages: core, bindings/java

Migration:
- Replace `old_api()` with `new_api()`.

Use package names from dev/src/release/package.rs. Include bindings affected by
behavior changes even when their source files are unchanged. Explain how users
can migrate, or explain the removal and available alternatives.
-->

# AI Usage Statement

<!--
If AI materially assisted this PR, list each harness/model/effort combination
that materially contributed, and briefly describe its role:

- Harness: Application or agent framework used to run the model.
- Model: Model name or identifier shown by the harness, with version if available.
- Effort: Reasoning effort setting as named by the harness.
- Role: AI's contribution and any assumptions or unknowns that affect review.

Do not include routine command output or repeat information provided elsewhere.

The author remains responsible for every submitted claim and change. If AI did
not materially assist this PR, write "None".
-->

- Harness: Claude Code
- Model: claude-opus-5
- Effort: default
- Role: Found the dangling symlink while verifying 0.59.2-rc.1, drafted the fix and doc change, and ran the checks on Linux. I reviewed and reproduced the build failure and the fix myself.