### PR TITLE
fix(bindings/java): install default HTTP transport on load

### DIFF
--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -35,7 +35,7 @@ jni = { version = "0.22.4" }
 # opendal-java won't be published to crates.io, we always use the local version
 opendal = { version = ">=0", path = "../../core", default-features = false, features = [
   "blocking",
-  "http-transport-reqwest-rustls",
+  "http-transport-reqwest",
   "executors-tokio",
 
   # enabled layers
@@ -108,6 +108,7 @@ tokio = { version = "1.49.0", features = ["full"] }
 # This is not optimal. See also the Cargo issue:
 # https://github.com/rust-lang/cargo/issues/1197#issuecomment-1641086954
 [target.'cfg(unix)'.dependencies.opendal]
+default-features = false
 features = [
   # Depend on "openssh" which depends on "tokio-pipe" that is unavailable on Windows.
   "services-sftp",

--- a/bindings/java/src/executor.rs
+++ b/bindings/java/src/executor.rs
@@ -43,7 +43,7 @@ pub unsafe extern "system" fn JNI_OnLoad(vm: *mut jni::sys::JavaVM, _: *mut c_vo
     // Register the JavaVM singleton so worker threads can attach to the JVM
     // later via `JavaVM::singleton()`.
     let _ = unsafe { JavaVM::from_raw(vm) };
-    opendal::init_default_registry();
+    opendal::install_default();
     jni::sys::JNI_VERSION_1_8
 }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/HttpTransportTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/HttpTransportTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.opendal.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.apache.opendal.AsyncExecutor;
+import org.apache.opendal.AsyncOperator;
+import org.apache.opendal.Operator;
+import org.apache.opendal.ServiceConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+public class HttpTransportTest {
+    @Test
+    @Timeout(10)
+    void testDefaultHttpTransport() throws Exception {
+        final byte[] content = "Hello, OpenDAL!".getBytes(StandardCharsets.UTF_8);
+        final HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/example.txt", exchange -> {
+            try {
+                exchange.sendResponseHeaders(200, content.length);
+                exchange.getResponseBody().write(content);
+            } finally {
+                exchange.close();
+            }
+        });
+        server.start();
+        try {
+            final ServiceConfig.Http config = ServiceConfig.Http.builder()
+                    .endpoint("http://127.0.0.1:" + server.getAddress().getPort())
+                    .build();
+            try (final AsyncExecutor executor = AsyncExecutor.createTokioExecutor(1);
+                    final AsyncOperator async = AsyncOperator.of(config, executor);
+                    final Operator blocking = async.blocking()) {
+                assertThat(async.read("example.txt").join()).isEqualTo(content);
+                assertThat(blocking.read("example.txt")).isEqualTo(content);
+            }
+        } finally {
+            server.stop(0);
+        }
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Related to #8270. This fixes the missing HTTP transport; the reported JVM shutdown hang remains separate.

# Rationale for this change

Java's `JNI_OnLoad` registers services without installing the default HTTP transport. Windows builds disable facade defaults, so HTTP operations fail with `default HTTP transport is not installed`. The Unix-only dependency declaration inadvertently re-enables default features and masks the missing initialization.

# What changes are included in this PR?

Call `opendal::install_default()` during JNI loading and enable `http-transport-reqwest`, which selects Rustls and enables transport installation. Keep default features disabled in the Unix dependency declaration so both platforms use explicit initialization. Add a Java regression test that reads from a local HTTP server through asynchronous and blocking operators. With automatic registration disabled, this test reproduces the reported `ConfigInvalid` error before the initialization fix and passes afterward.

# Are there any user-facing changes?

Java HTTP-backed services receive a default transport on Windows as well as Unix, without additional application configuration.

# AI Usage Statement

- Harness: Codex.
- Model: GPT-6; the exact model variant is not exposed in this session.
- Effort: Not exposed in this session.
- Role: Assisted diagnosis, implementation, regression testing, and PR drafting. Native Windows runtime validation is left to the existing Java CI matrix.
