### PR TITLE
fix(bindings/java): release default executor after its last owner

### DIFF
--- a/bindings/java/src/async_operator.rs
+++ b/bindings/java/src/async_operator.rs
@@ -17,8 +17,6 @@
 
 use std::time::Duration;
 
-use jni::AttachConfig;
-use jni::DEFAULT_LOCAL_FRAME_CAPACITY;
 use jni::Env;
 use jni::EnvUnowned;
 use jni::JavaVM;
@@ -29,7 +27,6 @@ use jni::objects::JClass;
 use jni::objects::JObject;
 use jni::objects::JString;
 use jni::objects::JValue;
-use jni::strings::JNIString;
 use jni::sys::jlong;
 use jni::sys::jsize;
 use opendal::Entry;
@@ -55,16 +52,26 @@ pub extern "system" fn Java_org_apache_opendal_AsyncOperator_constructor<'local>
     _: JClass<'local>,
     scheme: JString<'local>,
     map: JObject<'local>,
+    executor: *const Executor,
 ) -> jlong {
-    env.with_env(|env| intern_constructor(env, scheme, map))
+    env.with_env(|env| intern_constructor(env, scheme, map, executor))
         .resolve::<ThrowException>()
 }
 
-fn intern_constructor(env: &mut Env, scheme: JString, map: JObject) -> Result<jlong> {
+fn intern_constructor(
+    env: &mut Env,
+    scheme: JString,
+    map: JObject,
+    executor: *const Executor,
+) -> Result<jlong> {
     let scheme = jstring_to_string(env, &scheme)?;
     let map = jmap_to_hashmap(env, &map)?;
     let op = Operator::via_iter(scheme, map)?;
-    Ok(Box::into_raw(Box::new(op)) as jlong)
+    let executor = executor_or_default(executor)?;
+    let ctx = op
+        .context()
+        .with_executor(opendal::Executor::with(executor));
+    Ok(Box::into_raw(Box::new(op.with_context(ctx))) as jlong)
 }
 
 /// # Safety
@@ -119,7 +126,7 @@ fn intern_write(
     content: JByteArray,
     options: JObject,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let write_opts = make_write_options(env, &options)?;
@@ -160,7 +167,7 @@ fn intern_stat(
     path: JString,
     options: JObject,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let path = jstring_to_string(env, &path)?;
@@ -241,7 +248,7 @@ fn intern_delete(
     executor: *const Executor,
     path: JString,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let path = jstring_to_string(env, &path)?;
@@ -324,7 +331,7 @@ fn intern_create_dir(
     executor: *const Executor,
     path: JString,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let path = jstring_to_string(env, &path)?;
@@ -363,7 +370,7 @@ fn intern_copy(
     source_path: JString,
     target_path: JString,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let source_path = jstring_to_string(env, &source_path)?;
@@ -403,7 +410,7 @@ fn intern_rename(
     source_path: JString,
     target_path: JString,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let source_path = jstring_to_string(env, &source_path)?;
@@ -441,7 +448,7 @@ fn intern_remove_all(
     executor: *const Executor,
     path: JString,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let path = jstring_to_string(env, &path)?;
@@ -480,7 +487,7 @@ fn intern_list(
     path: JString,
     options: JObject,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let path = jstring_to_string(env, &path)?;
@@ -531,7 +538,7 @@ fn intern_presign_read(
     path: JString,
     expire: jlong,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let path = jstring_to_string(env, &path)?;
@@ -567,7 +574,7 @@ fn intern_presign_write(
     path: JString,
     expire: jlong,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let path = jstring_to_string(env, &path)?;
@@ -604,7 +611,7 @@ fn intern_presign_stat(
     path: JString,
     expire: jlong,
 ) -> Result<jlong> {
-    let op = unsafe { &mut *op };
+    let op = unsafe { &*op }.clone();
     let id = request_id(env)?;
 
     let path = jstring_to_string(env, &path)?;
@@ -620,44 +627,40 @@ fn intern_presign_stat(
 
 /// Complete the Java `CompletableFuture` identified by `id`.
 ///
-/// Attach the worker only while completing the future, so idle runtime threads
-/// do not prevent the JVM from exiting. The `build` closure turns the awaited
-/// operation result into a Java object; on error the future is completed
-/// exceptionally. All local references are released before the worker detaches.
+/// This runs on a `tokio` worker thread that was permanently attached to the
+/// JVM in `on_thread_start`, so `attach_current_thread` only pushes a scoped
+/// JNI frame here. The `build` closure turns the awaited operation result into a
+/// Java object within that frame; on error the future is completed
+/// exceptionally. All local references created during completion live and die
+/// within the frame.
 fn complete_future<F>(id: jlong, build: F)
 where
     F: for<'a> FnOnce(&mut Env<'a>) -> Result<JObject<'a>>,
 {
     let vm = JavaVM::singleton().expect("JavaVM singleton must be initialized");
-    let thread = std::thread::current();
-    let thread_name = JNIString::from(thread.name().expect("executor thread name must be set"));
-    vm.attach_current_thread_with_config(
-        || AttachConfig::new().scoped(true).thread_name(&thread_name),
-        Some(DEFAULT_LOCAL_FRAME_CAPACITY),
-        |env| -> Result<()> {
-            let future = get_future(env, id)?;
-            match build(env) {
-                Ok(object) => {
-                    env.call_method(
-                        &future,
-                        jni_str!("complete"),
-                        jni_sig!("(Ljava/lang/Object;)Z"),
-                        &[JValue::Object(&object)],
-                    )?;
-                }
-                Err(err) => {
-                    let exception = err.to_exception(env)?;
-                    env.call_method(
-                        &future,
-                        jni_str!("completeExceptionally"),
-                        jni_sig!("(Ljava/lang/Throwable;)Z"),
-                        &[JValue::Object(&exception)],
-                    )?;
-                }
+    vm.attach_current_thread(|env| -> Result<()> {
+        let future = get_future(env, id)?;
+        match build(env) {
+            Ok(object) => {
+                env.call_method(
+                    &future,
+                    jni_str!("complete"),
+                    jni_sig!("(Ljava/lang/Object;)Z"),
+                    &[JValue::Object(&object)],
+                )?;
             }
-            Ok(())
-        },
-    )
+            Err(err) => {
+                let exception = err.to_exception(env)?;
+                env.call_method(
+                    &future,
+                    jni_str!("completeExceptionally"),
+                    jni_sig!("(Ljava/lang/Throwable;)Z"),
+                    &[JValue::Object(&exception)],
+                )?;
+            }
+        }
+        Ok(())
+    })
     .expect("complete future must succeed");
 }
 

--- a/bindings/java/src/async_operator.rs
+++ b/bindings/java/src/async_operator.rs
@@ -17,6 +17,8 @@
 
 use std::time::Duration;
 
+use jni::AttachConfig;
+use jni::DEFAULT_LOCAL_FRAME_CAPACITY;
 use jni::Env;
 use jni::EnvUnowned;
 use jni::JavaVM;
@@ -27,6 +29,7 @@ use jni::objects::JClass;
 use jni::objects::JObject;
 use jni::objects::JString;
 use jni::objects::JValue;
+use jni::strings::JNIString;
 use jni::sys::jlong;
 use jni::sys::jsize;
 use opendal::Entry;
@@ -617,40 +620,44 @@ fn intern_presign_stat(
 
 /// Complete the Java `CompletableFuture` identified by `id`.
 ///
-/// This runs on a `tokio` worker thread that was permanently attached to the
-/// JVM in `on_thread_start`, so `attach_current_thread` only pushes a scoped
-/// JNI frame here. The `build` closure turns the awaited operation result into a
-/// Java object within that frame; on error the future is completed
-/// exceptionally. All local references created during completion live and die
-/// within the frame.
+/// Attach the worker only while completing the future, so idle runtime threads
+/// do not prevent the JVM from exiting. The `build` closure turns the awaited
+/// operation result into a Java object; on error the future is completed
+/// exceptionally. All local references are released before the worker detaches.
 fn complete_future<F>(id: jlong, build: F)
 where
     F: for<'a> FnOnce(&mut Env<'a>) -> Result<JObject<'a>>,
 {
     let vm = JavaVM::singleton().expect("JavaVM singleton must be initialized");
-    vm.attach_current_thread(|env| -> Result<()> {
-        let future = get_future(env, id)?;
-        match build(env) {
-            Ok(object) => {
-                env.call_method(
-                    &future,
-                    jni_str!("complete"),
-                    jni_sig!("(Ljava/lang/Object;)Z"),
-                    &[JValue::Object(&object)],
-                )?;
+    let thread = std::thread::current();
+    let thread_name = JNIString::from(thread.name().expect("executor thread name must be set"));
+    vm.attach_current_thread_with_config(
+        || AttachConfig::new().scoped(true).thread_name(&thread_name),
+        Some(DEFAULT_LOCAL_FRAME_CAPACITY),
+        |env| -> Result<()> {
+            let future = get_future(env, id)?;
+            match build(env) {
+                Ok(object) => {
+                    env.call_method(
+                        &future,
+                        jni_str!("complete"),
+                        jni_sig!("(Ljava/lang/Object;)Z"),
+                        &[JValue::Object(&object)],
+                    )?;
+                }
+                Err(err) => {
+                    let exception = err.to_exception(env)?;
+                    env.call_method(
+                        &future,
+                        jni_str!("completeExceptionally"),
+                        jni_sig!("(Ljava/lang/Throwable;)Z"),
+                        &[JValue::Object(&exception)],
+                    )?;
+                }
             }
-            Err(err) => {
-                let exception = err.to_exception(env)?;
-                env.call_method(
-                    &future,
-                    jni_str!("completeExceptionally"),
-                    jni_sig!("(Ljava/lang/Throwable;)Z"),
-                    &[JValue::Object(&exception)],
-                )?;
-            }
-        }
-        Ok(())
-    })
+            Ok(())
+        },
+    )
     .expect("complete future must succeed");
 }
 

--- a/bindings/java/src/executor.rs
+++ b/bindings/java/src/executor.rs
@@ -18,21 +18,27 @@
 use std::ffi::c_void;
 use std::future::Future;
 use std::num::NonZeroUsize;
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, Weak};
 use std::thread::available_parallelism;
 
+use jni::Env;
 use jni::EnvUnowned;
 use jni::JavaVM;
+use jni::jni_sig;
+use jni::jni_str;
 use jni::objects::JClass;
 use jni::objects::JObject;
+use jni::objects::JValue;
 use jni::sys::{jint, jlong};
 use tokio::task::JoinHandle;
 
 use crate::Result;
 use crate::error::ThrowException;
 
-static mut RUNTIME: OnceLock<Executor> = OnceLock::new();
+// Operators, derived resources, and in-flight tasks own the runtime. The cache
+// must not keep JVM-attached workers alive after those owners are released.
+static DEFAULT_RUNTIME: Mutex<Weak<Runtime>> = Mutex::new(Weak::new());
 
 #[unsafe(no_mangle)]
 pub unsafe extern "system" fn JNI_OnLoad(vm: *mut jni::sys::JavaVM, _: *mut c_void) -> jint {
@@ -43,19 +49,29 @@ pub unsafe extern "system" fn JNI_OnLoad(vm: *mut jni::sys::JavaVM, _: *mut c_vo
     jni::sys::JNI_VERSION_1_8
 }
 
-/// # Safety
-///
-/// This function could be only called by java vm when unload this lib.
-#[allow(static_mut_refs)]
-#[unsafe(no_mangle)]
-pub unsafe extern "system" fn JNI_OnUnload(_: *mut jni::sys::JavaVM, _: *mut c_void) {
-    unsafe {
-        RUNTIME.take();
+#[derive(Clone)]
+pub struct Executor {
+    runtime: Arc<Runtime>,
+}
+
+struct Runtime {
+    inner: Option<tokio::runtime::Runtime>,
+}
+
+impl Drop for Runtime {
+    fn drop(&mut self) {
+        // The last owner can be released by a completion callback on a worker.
+        // Initiate shutdown without blocking that worker waiting for itself.
+        if let Some(runtime) = self.inner.take() {
+            runtime.shutdown_background();
+        }
     }
 }
 
-pub enum Executor {
-    Tokio(tokio::runtime::Runtime),
+impl opendal::Execute for Executor {
+    fn execute(&self, future: opendal::raw::BoxedStaticFuture<()>) {
+        let _handle = self.spawn(future);
+    }
 }
 
 impl Executor {
@@ -63,12 +79,13 @@ impl Executor {
     where
         F: FnOnce() -> R,
     {
-        match self {
-            Executor::Tokio(e) => {
-                let _guard = e.enter();
-                f()
-            }
-        }
+        let runtime = self
+            .runtime
+            .inner
+            .as_ref()
+            .expect("runtime must be initialized");
+        let _guard = runtime.enter();
+        f()
     }
 
     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
@@ -76,9 +93,17 @@ impl Executor {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        match self {
-            Executor::Tokio(e) => e.spawn(future),
-        }
+        let owner = self.clone();
+        let runtime = self
+            .runtime
+            .inner
+            .as_ref()
+            .expect("runtime must be initialized");
+        runtime.spawn(async move {
+            let result = future.await;
+            drop(owner);
+            result
+        })
     }
 }
 
@@ -117,6 +142,24 @@ pub(crate) fn make_tokio_executor(cores: usize) -> Result<Executor> {
             let id = counter.fetch_add(1, Ordering::SeqCst);
             format!("opendal-tokio-worker-{id}")
         })
+        .on_thread_start(|| {
+            // `attach_current_thread` creates a permanent attachment; the thread
+            // is detached automatically when it exits.
+            let vm = JavaVM::singleton().expect("JavaVM singleton must be initialized");
+            vm.attach_current_thread(set_current_thread_name)
+                .expect("attach current thread must succeed");
+        })
+        .on_thread_stop(|| {
+            // Typically, the thread attached to the JVM will be detached automatically
+            // when the thread exits. However, there are some edge cases on Windows that
+            // may lead to deadlocks. To mitigate this, we explicitly detach the thread here.
+            //
+            // See https://github.com/apache/opendal/issues/6869 and
+            // https://github.com/jni-rs/jni-rs/issues/701 for more details.
+            if let Ok(vm) = JavaVM::singleton() {
+                let _ = vm.detach_current_thread();
+            }
+        })
         .enable_all()
         .build()
         .map_err(|e| {
@@ -126,37 +169,52 @@ pub(crate) fn make_tokio_executor(cores: usize) -> Result<Executor> {
             )
             .set_source(e)
         })?;
-    Ok(Executor::Tokio(executor))
+    Ok(Executor {
+        runtime: Arc::new(Runtime {
+            inner: Some(executor),
+        }),
+    })
 }
 
-/// # Panic
-///
-/// Crash if the executor is disposed.
+fn set_current_thread_name(env: &mut Env) -> Result<()> {
+    let current_thread = env
+        .call_static_method(
+            jni_str!("java/lang/Thread"),
+            jni_str!("currentThread"),
+            jni_sig!("()Ljava/lang/Thread;"),
+            &[],
+        )?
+        .l()?;
+    let thread_name = match std::thread::current().name() {
+        Some(thread_name) => env.new_string(thread_name)?,
+        None => unreachable!("thread name must be set"),
+    };
+    env.call_method(
+        &current_thread,
+        jni_str!("setName"),
+        jni_sig!("(Ljava/lang/String;)V"),
+        &[JValue::Object(&thread_name)],
+    )?;
+    Ok(())
+}
+
+/// Clone the supplied executor, or share the runtime owned by default operators.
 #[inline]
-pub(crate) fn executor_or_default(executor: *const Executor) -> Result<&'static Executor> {
-    unsafe {
-        if executor.is_null() {
-            default_executor()
-        } else {
-            // SAFETY: executor must be valid
-            Ok(&*executor)
-        }
-    }
-}
-
-/// # Safety
-///
-/// This function could be only when the lib is loaded.
-#[allow(static_mut_refs)]
-unsafe fn default_executor() -> Result<&'static Executor> {
-    // Return the executor if it's already initialized
-    if let Some(runtime) = unsafe { RUNTIME.get() } {
-        return Ok(runtime);
+pub(crate) fn executor_or_default(executor: *const Executor) -> Result<Executor> {
+    if !executor.is_null() {
+        // SAFETY: The caller must keep a supplied executor alive until its operators close.
+        return Ok(unsafe { &*executor }.clone());
     }
 
-    // Try to initialize the executor
+    let mut cached = DEFAULT_RUNTIME
+        .lock()
+        .expect("default runtime lock must not be poisoned");
+    if let Some(runtime) = cached.upgrade() {
+        return Ok(Executor { runtime });
+    }
+
     let executor =
         make_tokio_executor(available_parallelism().map(NonZeroUsize::get).unwrap_or(1))?;
-
-    Ok(unsafe { RUNTIME.get_or_init(|| executor) })
+    *cached = Arc::downgrade(&executor.runtime);
+    Ok(executor)
 }

--- a/bindings/java/src/executor.rs
+++ b/bindings/java/src/executor.rs
@@ -22,14 +22,10 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::available_parallelism;
 
-use jni::Env;
 use jni::EnvUnowned;
 use jni::JavaVM;
-use jni::jni_sig;
-use jni::jni_str;
 use jni::objects::JClass;
 use jni::objects::JObject;
-use jni::objects::JValue;
 use jni::sys::{jint, jlong};
 use tokio::task::JoinHandle;
 
@@ -121,24 +117,6 @@ pub(crate) fn make_tokio_executor(cores: usize) -> Result<Executor> {
             let id = counter.fetch_add(1, Ordering::SeqCst);
             format!("opendal-tokio-worker-{id}")
         })
-        .on_thread_start(|| {
-            // `attach_current_thread` creates a permanent attachment; the thread
-            // is detached automatically when it exits.
-            let vm = JavaVM::singleton().expect("JavaVM singleton must be initialized");
-            vm.attach_current_thread(set_current_thread_name)
-                .expect("attach current thread must succeed");
-        })
-        .on_thread_stop(|| {
-            // Typically, the thread attached to the JVM will be detached automatically
-            // when the thread exits. However, there are some edge cases on Windows that
-            // may lead to deadlocks. To mitigate this, we explicitly detach the thread here.
-            //
-            // See https://github.com/apache/opendal/issues/6869 and
-            // https://github.com/jni-rs/jni-rs/issues/701 for more details.
-            if let Ok(vm) = JavaVM::singleton() {
-                let _ = vm.detach_current_thread();
-            }
-        })
         .enable_all()
         .build()
         .map_err(|e| {
@@ -149,28 +127,6 @@ pub(crate) fn make_tokio_executor(cores: usize) -> Result<Executor> {
             .set_source(e)
         })?;
     Ok(Executor::Tokio(executor))
-}
-
-fn set_current_thread_name(env: &mut Env) -> Result<()> {
-    let current_thread = env
-        .call_static_method(
-            jni_str!("java/lang/Thread"),
-            jni_str!("currentThread"),
-            jni_sig!("()Ljava/lang/Thread;"),
-            &[],
-        )?
-        .l()?;
-    let thread_name = match std::thread::current().name() {
-        Some(thread_name) => env.new_string(thread_name)?,
-        None => unreachable!("thread name must be set"),
-    };
-    env.call_method(
-        &current_thread,
-        jni_str!("setName"),
-        jni_sig!("(Ljava/lang/String;)V"),
-        &[JValue::Object(&thread_name)],
-    )?;
-    Ok(())
 }
 
 /// # Panic

--- a/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
@@ -32,6 +32,11 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * AsyncOperator represents an underneath OpenDAL operator that
  * accesses data asynchronously.
+ *
+ * <p>Operators without an explicit executor share a default executor. Operators,
+ * derived streams, and outstanding operations keep it alive. Closing the last
+ * operator and stream releases it after outstanding operations complete; a later
+ * operator creates a new default executor.</p>
  */
 public class AsyncOperator extends NativeObject {
 
@@ -153,7 +158,7 @@ public class AsyncOperator extends NativeObject {
      */
     public static AsyncOperator of(String scheme, Map<String, String> map, AsyncExecutor executor) {
         final long executorHandle = executor != null ? executor.nativeHandle : 0;
-        final long nativeHandle = constructor(scheme, map);
+        final long nativeHandle = constructor(scheme, map, executorHandle);
         final OperatorInfo info = makeOperatorInfo(nativeHandle);
         return new AsyncOperator(nativeHandle, executorHandle, info);
     }
@@ -304,7 +309,7 @@ public class AsyncOperator extends NativeObject {
 
     private static native long duplicate(long nativeHandle);
 
-    private static native long constructor(String scheme, Map<String, String> map);
+    private static native long constructor(String scheme, Map<String, String> map, long executorHandle);
 
     private static native long read(long nativeHandle, long executorHandle, String path, ReadOptions options);
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/ExecutorShutdownTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/ExecutorShutdownTest.java
@@ -21,15 +21,19 @@ package org.apache.opendal.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.opendal.AsyncOperator;
 import org.apache.opendal.OpenDALException;
 import org.apache.opendal.Operator;
+import org.apache.opendal.layer.RetryLayer;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -39,7 +43,7 @@ public class ExecutorShutdownTest {
     Path tempDir;
 
     @ParameterizedTest
-    @ValueSource(strings = {"blocking", "async"})
+    @ValueSource(strings = {"blocking", "async", "derived", "streams", "callback", "recreate"})
     void testJvmExitsAfterClosingOperator(String mode) throws Exception {
         final String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
         final Path java = Paths.get(System.getProperty("java.home"), "bin", executable);
@@ -71,20 +75,82 @@ public class ExecutorShutdownTest {
     }
 
     public static class Application {
-        public static void main(String[] args) {
+        public static void main(String[] args) throws Exception {
             final byte[] content = "Hello, OpenDAL!".getBytes(StandardCharsets.UTF_8);
             if (args[0].equals("blocking")) {
                 try (final Operator op = Operator.of("memory", Collections.emptyMap())) {
                     op.write("example.txt", content);
                     assertThat(op.read("example.txt")).isEqualTo(content);
                 }
-            } else {
+            } else if (args[0].equals("async")) {
                 try (final AsyncOperator op = AsyncOperator.of("memory", Collections.emptyMap())) {
                     op.write("example.txt", content).join();
                     assertThat(op.read("example.txt").join()).isEqualTo(content);
                     assertThatThrownBy(() -> op.read("missing.txt").join()).hasCauseInstanceOf(OpenDALException.class);
                     assertThat(op.read("example.txt").join()).isEqualTo(content);
                 }
+            } else if (args[0].equals("derived")) {
+                try (final AsyncOperator original = AsyncOperator.of("memory", Collections.emptyMap());
+                        final AsyncOperator independent = AsyncOperator.of("memory", Collections.emptyMap());
+                        final AsyncOperator duplicate = original.duplicate();
+                        final AsyncOperator layered =
+                                duplicate.layer(RetryLayer.builder().build());
+                        final Operator blocking = layered.blocking();
+                        final Operator blockingDuplicate = blocking.duplicate()) {
+                    original.write("example.txt", content).join();
+                    original.close();
+                    independent.write("other.txt", content).join();
+                    assertThat(independent.read("other.txt").join()).isEqualTo(content);
+                    independent.close();
+                    assertThat(duplicate.read("example.txt").join()).isEqualTo(content);
+                    duplicate.close();
+                    assertThat(layered.read("example.txt").join()).isEqualTo(content);
+                    layered.close();
+                    assertThat(blocking.read("example.txt")).isEqualTo(content);
+                    blocking.close();
+                    assertThat(blockingDuplicate.read("example.txt")).isEqualTo(content);
+                }
+            } else if (args[0].equals("streams")) {
+                try (final Operator op = Operator.of("memory", Collections.emptyMap())) {
+                    op.write("example.txt", content);
+                    try (final InputStream reader = op.createInputStream("example.txt")) {
+                        op.close();
+                        final byte[] actual = new byte[content.length];
+                        assertThat(reader.read(actual)).isEqualTo(content.length);
+                        assertThat(actual).isEqualTo(content);
+                    }
+                }
+                try (final Operator op = Operator.of("memory", Collections.emptyMap());
+                        final OutputStream writer = op.createOutputStream("example.txt")) {
+                    op.close();
+                    writer.write(content);
+                }
+            } else if (args[0].equals("callback")) {
+                try (final AsyncOperator op = AsyncOperator.of("memory", Collections.emptyMap())) {
+                    op.write("example.txt", content).join();
+                    op.read("example.txt")
+                            .thenAccept(actual -> {
+                                assertThat(actual).isEqualTo(content);
+                                op.close();
+                            })
+                            .join();
+                }
+            } else if (args[0].equals("recreate")) {
+                for (int round = 0; round < 3; round++) {
+                    final CompletableFuture<?>[] operations = new CompletableFuture<?>[4];
+                    for (int i = 0; i < operations.length; i++) {
+                        operations[i] = CompletableFuture.runAsync(() -> {
+                            try (final AsyncOperator op = AsyncOperator.of("memory", Collections.emptyMap())) {
+                                final CompletableFuture<Void> write = op.write("example.txt", content);
+                                op.close();
+                                write.join();
+                            }
+                        });
+                    }
+                    CompletableFuture.allOf(operations).join();
+                }
+            } else {
+                throw new IllegalArgumentException(args[0]);
             }
             System.out.println("OPERATORS_CLOSED");
         }

--- a/bindings/java/src/test/java/org/apache/opendal/test/ExecutorShutdownTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/ExecutorShutdownTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.opendal.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.apache.opendal.AsyncOperator;
+import org.apache.opendal.OpenDALException;
+import org.apache.opendal.Operator;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ExecutorShutdownTest {
+    @TempDir
+    Path tempDir;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"blocking", "async"})
+    void testJvmExitsAfterClosingOperator(String mode) throws Exception {
+        final String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+        final Path java = Paths.get(System.getProperty("java.home"), "bin", executable);
+        final Path log = tempDir.resolve(mode + ".log");
+        final Process process = new ProcessBuilder(
+                        java.toString(),
+                        "-Xcheck:jni",
+                        "-Djava.library.path=" + System.getProperty("java.library.path"),
+                        "-cp",
+                        System.getProperty("surefire.test.class.path", System.getProperty("java.class.path")),
+                        Application.class.getName(),
+                        mode)
+                .redirectErrorStream(true)
+                .redirectOutput(log.toFile())
+                .start();
+        final boolean exited;
+        try {
+            exited = process.waitFor(15, TimeUnit.SECONDS);
+        } finally {
+            if (process.isAlive()) {
+                process.destroyForcibly();
+                process.waitFor(5, TimeUnit.SECONDS);
+            }
+        }
+        final String output = new String(Files.readAllBytes(log), StandardCharsets.UTF_8);
+        assertThat(output).contains("OPERATORS_CLOSED");
+        assertThat(exited).as("JVM must exit after main returns: %s", output).isTrue();
+        assertThat(process.exitValue()).as(output).isZero();
+    }
+
+    public static class Application {
+        public static void main(String[] args) {
+            final byte[] content = "Hello, OpenDAL!".getBytes(StandardCharsets.UTF_8);
+            if (args[0].equals("blocking")) {
+                try (final Operator op = Operator.of("memory", Collections.emptyMap())) {
+                    op.write("example.txt", content);
+                    assertThat(op.read("example.txt")).isEqualTo(content);
+                }
+            } else {
+                try (final AsyncOperator op = AsyncOperator.of("memory", Collections.emptyMap())) {
+                    op.write("example.txt", content).join();
+                    assertThat(op.read("example.txt").join()).isEqualTo(content);
+                    assertThatThrownBy(() -> op.read("missing.txt").join()).hasCauseInstanceOf(OpenDALException.class);
+                    assertThat(op.read("example.txt").join()).isEqualTo(content);
+                }
+            }
+            System.out.println("OPERATORS_CLOSED");
+        }
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Related to #8270. This fixes the JVM shutdown hang. The HTTP transport initialization failure is handled separately in #8288.

# Rationale for this change

After the JNI 0.22 migration, Tokio workers attach as non-daemon JVM threads. The global runtime owns those workers for the lifetime of the library, so closing all operators leaves the JVM waiting for idle threads after `main` returns.

# What changes are included in this PR?

Store a shared executor in the operator's existing `OperationContext`, so derived operators and streams retain the runtime they use. Cache the default runtime through a weak reference, and let dispatched operations retain their operator and executor through completion. When the last owner releases the runtime, initiate shutdown without blocking a worker that may itself be releasing the final reference.

Keep JNI attachment once per worker lifetime. Add child-JVM tests with `-Xcheck:jni` for blocking and asynchronous operations, derived operators, streams that outlive their operator, closing from a completion callback, and concurrent creation/recreation. The original blocking and async exit tests both timed out on the base revision and pass with this change.

# Are there any user-facing changes?

Closing the last operator and stream allows the JVM to exit after outstanding operations complete. A later operator can create a new shared default executor. The public Java API is unchanged.

## Benchmark

Sequential async reads of an 8-byte memory value, using one dedicated executor worker:

| Revision | Time per read |
| --- | ---: |
| Base `af79667fc` | 31.4 µs |
| Fix `e39428e24` | 31.0 µs |

Local macOS arm64 debug builds on OpenJDK 17; median of three 5,000-read rounds after 2,000 warmup reads. These measurements cover per-operation overhead with in-memory data.

# AI Usage Statement

- Harness: Codex.
- Model: GPT-6; the exact model variant is not exposed in this session.
- Effort: Not exposed in this session.
- Role: Assisted diagnosis, implementation, lifecycle testing, measurement, and PR drafting. Native Windows and Linux runtime validation is left to the existing Java CI matrix.
