### PR TITLE
fix(services/webdav): support streaming writes with content-range chunks

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -7547,6 +7547,7 @@ version = "0.59.1"
 dependencies = [
  "anyhow",
  "bytes",
+ "futures",
  "http 1.4.2",
  "log",
  "opendal-core",

--- a/core/services/webdav/Cargo.toml
+++ b/core/services/webdav/Cargo.toml
@@ -41,4 +41,5 @@ quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+futures = { workspace = true, features = ["std", "async-await"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -226,6 +226,7 @@ impl Builder for WebdavBuilder {
                 read_with_if_unmodified_since: conditional_read,
 
                 write: true,
+                write_can_multi: true,
                 write_can_empty: true,
                 write_with_user_metadata: true,
 
@@ -269,7 +270,7 @@ pub struct WebdavBackend {
 
 impl Service for WebdavBackend {
     type Reader = oio::StreamReader<WebdavReader>;
-    type Writer = oio::OneShotWriter<WebdavWriter>;
+    type Writer = WebdavWriter;
     type Lister = oio::PageLister<WebdavLister>;
     type Deleter = oio::OneShotDeleter<WebdavDeleter>;
     type Copier = oio::OneShotCopier;
@@ -311,14 +312,7 @@ impl Service for WebdavBackend {
     }
 
     fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
-        let output: oio::OneShotWriter<WebdavWriter> = {
-            Ok(oio::OneShotWriter::new(WebdavWriter::new(
-                self.core.clone(),
-                ctx.clone(),
-                args,
-                path.to_string(),
-            )))
-        }?;
+        let output = WebdavWriter::new(self.core.clone(), ctx.clone(), args, path.to_string());
 
         Ok(output)
     }

--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -258,6 +258,50 @@ impl WebdavCore {
         ctx.http_transport().send(req).await
     }
 
+    /// Send a partial PUT request carrying `Content-Range`.
+    ///
+    /// The chunk is written at `offset` inside an existing file. The complete
+    /// length is unknown while streaming, so the header uses `*`.
+    ///
+    /// # Reference
+    /// - [Apache-style PUT with Content-Range](https://github.com/messense/dav-server-rs/tree/main/doc/Apache-PUT-with-Content-Range.md)
+    pub async fn webdav_put_range(
+        &self,
+        ctx: &OperationContext,
+        path: &str,
+        offset: u64,
+        args: &OpWrite,
+        body: Buffer,
+    ) -> Result<Response<Buffer>> {
+        let path = build_rooted_abs_path(&self.root, path);
+        let url = format!("{}{}", self.endpoint, percent_encode_path(&path));
+
+        let mut req = Request::put(&url);
+
+        if let Some(v) = &self.authorization {
+            req = req.header(header::AUTHORIZATION, v)
+        }
+
+        let size = body.len() as u64;
+        req = req.header(header::CONTENT_LENGTH, size);
+        req = req.header(
+            header::CONTENT_RANGE,
+            format!("bytes {}-{}/*", offset, offset + size - 1),
+        );
+
+        if let Some(v) = args.content_type() {
+            req = req.header(header::CONTENT_TYPE, v)
+        }
+
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("Put"))
+            .body(body)
+            .map_err(new_request_build_error)?;
+
+        ctx.http_transport().send(req).await
+    }
+
     /// Set user-defined metadata using WebDAV PROPPATCH method.
     ///
     /// This method uses the OpenDAL custom namespace to store user metadata

--- a/core/services/webdav/src/writer.rs
+++ b/core/services/webdav/src/writer.rs
@@ -24,12 +24,38 @@ use super::core::*;
 use opendal_core::raw::*;
 use opendal_core::*;
 
+/// Write progress of the streaming writer.
+///
+/// The writer starts in [`Progress::New`] and moves to [`Progress::Started`]
+/// once the first chunk has been written.
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+enum Progress {
+    /// No chunk has been written yet: the next chunk creates or truncates the file.
+    New,
+    /// The file already holds `offset` bytes: the next chunk appends with `Content-Range`.
+    Started {
+        /// Offset of the next chunk, equal to the number of bytes written so far.
+        offset: u64,
+        /// Metadata parsed from the latest write response.
+        metadata: Metadata,
+    },
+}
+
+/// WebDAV writer that streams data in ordered chunks.
+///
+/// The first chunk uses a regular PUT, which creates or truncates the file.
+/// Following chunks use partial PUTs carrying `Content-Range`, so the writer
+/// never needs to hold the whole file in memory.
 pub struct WebdavWriter {
     core: Arc<WebdavCore>,
     ctx: OperationContext,
 
     op: OpWrite,
     path: String,
+
+    /// Write progress that decides how the next chunk is sent.
+    progress: Progress,
 }
 
 impl WebdavWriter {
@@ -39,6 +65,7 @@ impl WebdavWriter {
             ctx,
             op,
             path,
+            progress: Progress::New,
         }
     }
 
@@ -55,10 +82,22 @@ impl WebdavWriter {
 
         Ok(metadata.build())
     }
-}
 
-impl oio::OneShotWrite for WebdavWriter {
-    async fn write_once(&self, bs: Buffer) -> Result<Metadata> {
+    /// Parse a write response, returning its metadata on success.
+    fn parse_write_response(resp: http::Response<Buffer>) -> Result<Metadata> {
+        match resp.status() {
+            StatusCode::CREATED | StatusCode::OK | StatusCode::NO_CONTENT => {
+                Self::parse_metadata(resp.headers())
+            }
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Put")),
+                resp,
+            )),
+        }
+    }
+
+    /// Write the first chunk with a regular PUT, which creates or truncates the file.
+    async fn write_first(&mut self, bs: Buffer) -> Result<Metadata> {
         // Ensure parent path exists unless disabled for servers that don't support PROPFIND.
         if !self.core.disable_create_dir {
             self.core
@@ -70,43 +109,107 @@ impl oio::OneShotWrite for WebdavWriter {
             .core
             .webdav_put(&self.ctx, &self.path, Some(bs.len() as u64), &self.op, bs)
             .await?;
+        let metadata = Self::parse_write_response(resp)?;
 
-        let status = resp.status();
+        // Set user metadata using PROPPATCH if provided
+        if let Some(user_metadata) = self.op.user_metadata() {
+            let user_metadata = user_metadata
+                .into_iter()
+                .map(|(key, value)| (key.to_owned(), value.to_owned()))
+                .collect();
+            let proppatch_resp = self
+                .core
+                .webdav_proppatch(&self.ctx, &self.path, &user_metadata)
+                .await?;
 
-        match status {
-            StatusCode::CREATED | StatusCode::OK | StatusCode::NO_CONTENT => {
-                let metadata = WebdavWriter::parse_metadata(resp.headers())?;
-
-                // Set user metadata using PROPPATCH if provided
-                if let Some(user_metadata) = self.op.user_metadata() {
-                    let user_metadata = user_metadata
-                        .into_iter()
-                        .map(|(key, value)| (key.to_owned(), value.to_owned()))
-                        .collect();
-                    let proppatch_resp = self
-                        .core
-                        .webdav_proppatch(&self.ctx, &self.path, &user_metadata)
-                        .await?;
-
-                    let proppatch_status = proppatch_resp.status();
-                    // PROPPATCH returns 207 Multi-Status - need to check response body
-                    // for actual success/failure status
-                    if proppatch_status == StatusCode::MULTI_STATUS {
-                        let body = proppatch_resp.into_body().to_bytes();
-                        let xml = String::from_utf8_lossy(&body);
-                        check_proppatch_response(&xml)?;
-                    } else if !proppatch_status.is_success() {
-                        return Err(parse_error(
-                            ErrorContext::new(ServiceOperation("Proppatch")),
-                            proppatch_resp,
-                        ));
-                    }
-                }
-
-                Ok(metadata)
+            let proppatch_status = proppatch_resp.status();
+            // PROPPATCH returns 207 Multi-Status - need to check response body
+            // for actual success/failure status
+            if proppatch_status == StatusCode::MULTI_STATUS {
+                let body = proppatch_resp.into_body().to_bytes();
+                let xml = String::from_utf8_lossy(&body);
+                check_proppatch_response(&xml)?;
+            } else if !proppatch_status.is_success() {
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("Proppatch")),
+                    proppatch_resp,
+                ));
             }
+        }
+
+        Ok(metadata)
+    }
+
+    /// Write a following chunk at `offset` with a partial PUT carrying `Content-Range`.
+    async fn write_next(&mut self, bs: Buffer, offset: u64) -> Result<Metadata> {
+        let resp = self
+            .core
+            .webdav_put_range(&self.ctx, &self.path, offset, &self.op, bs)
+            .await?;
+        let metadata = Self::parse_write_response(resp)?;
+        Ok(metadata)
+    }
+}
+
+impl oio::Write for WebdavWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        let size = bs.len();
+        if size == 0 {
+            return Ok(());
+        }
+
+        let offset = match &self.progress {
+            Progress::New => None,
+            Progress::Started { offset, .. } => Some(*offset),
+        };
+        match offset {
+            None => {
+                let metadata = self.write_first(bs).await?;
+                self.progress = Progress::Started {
+                    offset: size as u64,
+                    metadata,
+                };
+            }
+            Some(offset) => {
+                let metadata = self.write_next(bs, offset).await?;
+                self.progress = Progress::Started {
+                    offset: offset + size as u64,
+                    metadata,
+                };
+            }
+        }
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        if matches!(self.progress, Progress::New) {
+            // Keep the semantics of the one-shot writer: create an empty file
+            // when nothing has been written.
+            let metadata = self.write_first(Buffer::new()).await?;
+            self.progress = Progress::Started {
+                offset: 0,
+                metadata,
+            };
+        }
+
+        match &self.progress {
+            Progress::Started { metadata, .. } => Ok(metadata.clone()),
+            // `Progress::New` moves to `Progress::Started` above, so this branch
+            // is unreachable; return unknown metadata instead of panicking.
+            Progress::New => Ok(MetadataBuilder::unknown().build()),
+        }
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        if matches!(self.progress, Progress::New) {
+            return Ok(());
+        }
+
+        let resp = self.core.webdav_delete(&self.ctx, &self.path).await?;
+        match resp.status() {
+            StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(()),
             _ => Err(parse_error(
-                ErrorContext::new(ServiceOperation("Put")),
+                ErrorContext::new(ServiceOperation("Delete")),
                 resp,
             )),
         }

--- a/core/services/webdav/tests/stream_write.rs
+++ b/core/services/webdav/tests/stream_write.rs
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Streaming write tests for the WebDAV service.
+//!
+//! A streaming writer performs multiple writes on one object. A wasm client
+//! relies on this to upload files larger than one internal buffer without
+//! keeping the whole file in memory. These tests drive the service through a
+//! mock HTTP transport, so they need no WebDAV server.
+
+use {
+    futures::{AsyncWriteExt, stream},
+    http::{Method, Request, Response, StatusCode, header},
+    opendal_core::{
+        Buffer, HttpBody, HttpTransport, HttpTransporter, OperationContext, Operator, Result,
+    },
+    opendal_service_webdav::Webdav,
+    std::sync::{Arc, Mutex},
+};
+
+/// An HTTP request recorded by [`MockTransport`].
+#[derive(Clone, Debug)]
+struct RecordedRequest {
+    method: Method,
+    content_range: Option<String>,
+    body: Vec<u8>,
+}
+
+/// A mock transport that records requests and answers them like a WebDAV server.
+#[derive(Clone, Debug, Default)]
+struct MockTransport {
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+}
+
+impl MockTransport {
+    /// Returns all requests recorded so far.
+    fn requests(&self) -> Vec<RecordedRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl HttpTransport for MockTransport {
+    async fn fetch(&self, request: Request<Buffer>) -> Result<Response<HttpBody>> {
+        let content_range = request
+            .headers()
+            .get(header::CONTENT_RANGE)
+            .map(|value| value.to_str().unwrap().to_owned());
+        let recorded = RecordedRequest {
+            method: request.method().clone(),
+            content_range,
+            body: request.body().to_bytes().to_vec(),
+        };
+        self.requests.lock().unwrap().push(recorded.clone());
+
+        // The service stats the parent directory with PROPFIND before MKCOL.
+        let status = match recorded.method.as_str() {
+            "PUT" if recorded.content_range.is_some() => StatusCode::NO_CONTENT,
+            "PUT" => StatusCode::CREATED,
+            "MKCOL" => StatusCode::CREATED,
+            "PROPFIND" => StatusCode::NOT_FOUND,
+            _ => StatusCode::OK,
+        };
+        let body = HttpBody::new(stream::empty::<Result<Buffer>>(), Some(0));
+        Ok(Response::builder().status(status).body(body).unwrap())
+    }
+}
+
+/// Builds an operator whose requests are handled by the mock transport.
+fn operator(transport: MockTransport) -> Operator {
+    let webdav = Webdav::default().endpoint("http://webdav.example.com");
+    let context = OperationContext::new().with_http_transport(HttpTransporter::new(transport));
+    Operator::new(webdav).unwrap().with_context(context)
+}
+
+/// The service reports that one writer accepts multiple writes, which the
+/// streaming upload path relies on.
+#[tokio::test]
+async fn capability_reports_stream_write_support() {
+    let operator = operator(MockTransport::default());
+
+    assert!(operator.info().capability().write_can_multi);
+}
+
+/// Writing more than one internal buffer through a single writer uploads every
+/// chunk in order and keeps the content intact.
+#[tokio::test]
+async fn stream_write_larger_than_buffer_uploads_all_chunks() {
+    let transport = MockTransport::default();
+    let operator = operator(transport.clone());
+
+    let payload = (0..600 * 1024)
+        .map(|index| (index % 251) as u8)
+        .collect::<Vec<u8>>();
+    let mut writer = operator
+        .writer("big.bin")
+        .await
+        .unwrap()
+        .into_futures_async_write();
+    writer.write_all(&payload).await.unwrap();
+    writer.close().await.unwrap();
+
+    // The first chunk is a regular PUT; the following chunks append with
+    // Content-Range so the server keeps the earlier chunks.
+    let puts = transport
+        .requests()
+        .into_iter()
+        .filter(|request| request.method == Method::PUT)
+        .collect::<Vec<_>>();
+    assert_eq!(puts.len(), 3);
+    assert_eq!(puts[0].content_range, None);
+    assert_eq!(
+        puts[1].content_range.as_deref(),
+        Some("bytes 262144-524287/*")
+    );
+    assert_eq!(
+        puts[2].content_range.as_deref(),
+        Some("bytes 524288-614399/*")
+    );
+    let uploaded = puts
+        .iter()
+        .flat_map(|put| put.body.iter().copied())
+        .collect::<Vec<u8>>();
+    assert_eq!(uploaded, payload);
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #8291.

# Rationale for this change

The WebDAV service used `oio::OneShotWriter`, so a single writer only accepted one `write` call. `FuturesAsyncWriter` flushes its 256 KiB buffer with a second `write` once the data grows past one buffer, and the one-shot writer rejected it with `OneShotWriter doesn't support multiple write`. This made streaming uploads of files larger than 256 KiB impossible.

# What changes are included in this PR?

- Implement `oio::Write` for `WebdavWriter` instead of `oio::OneShotWrite`:
  - the first chunk uses a regular PUT, which creates or truncates the file;
  - following chunks use partial PUTs carrying `Content-Range` to append at the current offset;
  - `abort` deletes the partially written file.
- Add `WebdavCore::webdav_put_range` to send partial PUT requests.
- Report `write_can_multi = true` for the webdav service.
- Add integration tests that drive the writer through a mock HTTP transport.

# Are there any user-facing changes?

- `write_can_multi` is now `true` for webdav.
- Streaming writes larger than one buffer now work against servers that support Apache-style partial PUTs with `Content-Range`. Against servers without that support the write fails with the server's response instead of the previous client-side one-shot error.

# AI Usage Statement

This change was developed with AI assistance (opencode, deepseek-v4-flash).
